### PR TITLE
Refactor2 the proxying

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 *
 !requirements.txt
 !galactory/
-!galactory.py
+!LICENSE
+!setup.cfg
+!pyproject.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,15 @@ name: Test
 on:
   push:
     branches: [main]
+    tags: ['v*.*.*']
 
   pull_request:
     branches: [main]
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,8 +37,11 @@ jobs:
       - name: Pytest
         run: pytest tests/
 
-  docker:
+
+  build:
     needs: [test]
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,13 +52,69 @@ jobs:
       - name: Run container
         run: docker run --rm galactory --help
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Pre-reqs
+        run: pip install --upgrade pip setuptools build
+
+      - name: Build
+        run: python -m build
+
+      - name: Check version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          VER_TAG=${GITHUB_REF/refs\/tags\/v/}
+          echo "::set-output name=relver::${VER_TAG}"
+
+          expected_sdist=galactory-${VER_TAG}.tar.gz
+          expected_wheel=galactory-${VER_TAG}-py3-none-any.whl
+
+          if [ ! -f "dist/${expected_sdist}"] || [ ! -f "dist/${expected_wheel}" ]
+          then
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+          retention-days: ${{ github.event_name == 'push' && 90 || 7 }}
+          if-no-files-found: error
+
+
+  release:
+    needs: [build]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      UPSTREAM: ghcr.io/${{ github.repository_owner }}/galactory
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build container
+        run: docker build -t ${UPSTREAM}:latest -t ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.build.outputs.relver || github.sha }} .
+
+      - name: Run container
+        run: docker run --rm galactory --help
+
       - name: Login to registry
         if: github.event_name == 'push'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push to registry
         if: github.event_name == 'push'
-        run: |
-          UPSTREAM=ghcr.io/${{ github.repository_owner }}/galactory
-          docker tag galactory ${UPSTREAM}:latest
-          docker push ${UPSTREAM}:latest
+        run: docker push --all-tags
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+      - uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: dist/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM python:3.10-slim
+FROM python:3.10-slim as build
 
-COPY requirements.txt /tmp/requirements.txt
+RUN python -m venv /venv
+ENV PATH=/venv/bin:$PATH
 
-RUN pip install --no-cache-dir --upgrade pip setuptools \
-    && pip install --no-cache-dir -r /tmp/requirements.txt \
-    && rm /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools build
 
-COPY . .
+COPY . /galactory
 
-ENTRYPOINT [ "python", "galactory.py" ]
+RUN pip install ./galactory
+
+
+FROM python:3.10-slim as final
+
+COPY --from=build /venv /venv
+ENV PATH=/venv/bin:$PATH
+
+ENTRYPOINT [ "python", "-m", "galactory" ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/galactory/__init__.py
+++ b/galactory/__init__.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from flask import Flask, request
 from flask.json import JSONEncoder
 from .api import bp as api
+from .download import bp as download
 
 
 class DateTimeIsoFormatJSONEncoder(JSONEncoder):
@@ -20,6 +21,7 @@ def create_app(**config):
     app.json_encoder = DateTimeIsoFormatJSONEncoder
     app.config.update(**config)
     app.register_blueprint(api)
+    app.register_blueprint(download)
 
     @app.before_request
     def log():

--- a/galactory/__init__.py
+++ b/galactory/__init__.py
@@ -15,9 +15,10 @@ class DateTimeIsoFormatJSONEncoder(JSONEncoder):
         return super().default(o)
 
 
-def create_app():
+def create_app(**config):
     app = Flask(__name__)
     app.json_encoder = DateTimeIsoFormatJSONEncoder
+    app.config.update(**config)
     app.register_blueprint(api)
 
     @app.before_request

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -1,24 +1,28 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # (c) 2022 Brian Scholer (@briantist)
 
+import os
 import logging
 from argparse import ArgumentParser
 from artifactory import ArtifactoryPath
 
-from galactory import create_app
+from . import create_app
 
 
 if __name__ == '__main__':
     parser = ArgumentParser(
+        prog='python -m galactory',
         description=(
             'galactory is a partial Ansible Galaxy proxy that uploads and downloads collections, '
             'using an Artifactory generic repository as its backend.'
-        )
+        ),
     )
     parser.add_argument('--listen-addr', default='0.0.0.0', type=str, help='The IP address to listen on.')
     parser.add_argument('--listen-port', default=5555, type=int, help='The TCP port to listen on.')
     parser.add_argument('--artifactory-path', type=str, required=True, help='The URL of the path in Artifactory where collections are stored.')
+    parser.add_argument('--artifactory-api-key', default=os.environ.get('GALACTORY_ARTIFACTORY_API_KEY'), help='If set, is the API key used to access Artifactory.')
+    parser.add_argument('--use-galaxy-key', action='store_true', help='If set, uses the Galaxy token as the Artifactory API key.')
+    parser.add_argument('--prefer-configured-key', action='store_true', help='If set, prefer the confgured Artifactory key over the Galaxy token.')
     parser.add_argument('--log-file', type=str, help='If set, logging will go to this file instead of the console.')
     parser.add_argument(
         '--log-level',
@@ -28,16 +32,22 @@ if __name__ == '__main__':
     )
     parser.add_argument('--log-headers', action='store_true', help='Log the headers of every request (DEBUG level only).')
     parser.add_argument('--log-body', action='store_true', help='Log the body of every request (DEBUG level only).')
+    parser.add_argument('--proxy-upstream', type=lambda x: str(x).rstrip('/') + '/', help='If set, then find, pull and cache results from the specified galaxy server in addition to local.')
+    parser.add_argument('-npns', '--no-proxy-namespace', action='append', default=[], help='Requests for this namespace should never be proxied. Can be specified multiple times.')
     args = parser.parse_args()
 
     logging.basicConfig(filename=args.log_file, level=args.log_level)
 
-    app = create_app()
-
-    app.config.update(
+    app = create_app(
         ARTIFACTORY_PATH=ArtifactoryPath(args.artifactory_path),
         LOG_HEADERS=args.log_headers,
         LOG_BODY=args.log_body,
+        PROXY_UPSTREAM=args.proxy_upstream,
+        NO_PROXY_NAMESPACES=args.no_proxy_namespace,
+        ARTIFACTORY_API_KEY=args.artifactory_api_key,
+        USE_GALAXY_KEY=args.use_galaxy_key,
+        PREFER_CONFIGURED_KEY=args.prefer_configured_key,
     )
+
     print(app.url_map)
     app.run(args.listen_addr, args.listen_port, threaded=True)

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -4,7 +4,7 @@
 import semver
 import json
 from base64io import Base64IO
-from artifactory import ArtifactoryPath, ArtifactoryException
+from artifactory import ArtifactoryException
 from flask import Response, jsonify, abort, url_for, request, current_app
 
 from . import bp as v2

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -49,7 +49,7 @@ def versions(namespace, collection):
             results.append(
                 {
                     'href': url_for(
-                        'version',
+                        'api.v2.version',
                         namespace=i['namespace']['name'],
                         collection=i['name'],
                         version=v,
@@ -84,6 +84,7 @@ def version(namespace, collection, version):
             'size': info['size'],
         },
         'collection': {
+            'href': url_for('api.v2.collection', namespace=namespace, collection=collection, _external=True),
             'name': info['name'],
         },
         'namespace': info['namespace'],
@@ -124,7 +125,7 @@ def publish():
         }
         target.properties = props
 
-    return jsonify(task=url_for('import_singleton', _external=True))
+    return jsonify(task=url_for('api.v2.import_singleton', _external=True))
 
 
 # TODO: optionally proxy the download from artifactory

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -4,7 +4,7 @@
 import semver
 import json
 from base64io import Base64IO
-from artifactory import ArtifactoryException
+from artifactory import ArtifactoryPath, ArtifactoryException
 from flask import Response, jsonify, abort, url_for, request, current_app
 
 from . import bp as v2
@@ -180,10 +180,3 @@ def publish():
             target.properties = props
 
     return jsonify(task=url_for('api.v2.import_singleton', _external=True))
-
-
-# TODO: optionally proxy the download from artifactory
-# will be useful if repo requires authentication to download
-# @app.route('/collections/download/<filename>')
-# def download(filename):
-#     pass

--- a/galactory/download/__init__.py
+++ b/galactory/download/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 Brian Scholer (@briantist)
+
+from flask import Blueprint
+
+bp = Blueprint('download', __name__, url_prefix='/download')
+
+from . import download

--- a/galactory/download/download.py
+++ b/galactory/download/download.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 Brian Scholer (@briantist)
+
+import json
+
+from flask import abort, request, current_app, send_file, Response
+from artifactory import ArtifactoryException
+
+from . import bp as dl
+from .. import constants as C
+from ..utilities import load_manifest_from_artifactory, authorize, _chunk_to_temp
+from ..upstream import ProxyUpstream
+
+
+@dl.route('/<filename>')
+def download(filename):
+    artifact = authorize(request, current_app.config['ARTIFACTORY_PATH'] / filename)
+
+    try:
+        stat = artifact.stat()
+    except FileNotFoundError:
+        try:
+            upstream = current_app.config['PROXY_UPSTREAM']
+        except KeyError:
+            abort(C.HTTP_NOT_FOUND)
+
+        proxy = ProxyUpstream(artifact, upstream)
+
+        with proxy.proxy_download(request) as resp, _chunk_to_temp(None, iterator=resp.iter_content) as tmp:
+            try:
+                artifact.deploy(tmp.handle, md5=tmp.md5, sha1=tmp.sha1, sha256=tmp.sha256)
+            except ArtifactoryException as exc:
+                cause = exc.__cause__
+                current_app.logger.debug(cause)
+                abort(Response(cause.response.text, cause.response.status_code))
+            else:
+                manifest = load_manifest_from_artifactory(artifact)
+                ci = manifest['collection_info']
+                props = {
+                    'collection_info': json.dumps(ci),
+                    'namespace': ci['namespace'],
+                    'name': ci['name'],
+                    'version': ci['version'],
+                    'fqcn': f"{ci['namespace']}.{ci['name']}"
+                }
+                artifact.properties = props
+                stat = artifact.stat()
+
+    return send_file(artifact.open(), as_attachment=True, download_name=artifact.name, last_modified=stat.mtime, etag=False)

--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 Brian Scholer (@briantist)
+
+import requests
+import json
+
+from contextlib import contextmanager
+from io import StringIO
+from datetime import datetime, timedelta
+from artifactory import ArtifactoryException
+
+from flask import current_app, abort, Response
+
+from . import constants as C
+
+
+class _CacheEntry:
+    _raw = {}
+
+    @classmethod
+    def from_file(cls, f, **kwargs):
+        def _time_decoder(pairs):
+            d = {}
+            for k, v in pairs:
+                try:
+                    nv = datetime.fromisoformat(v)
+                except (ValueError, TypeError):
+                    d[k] = v
+                else:
+                    d[k] = nv
+
+            return d
+
+        loaded = json.load(f, object_pairs_hook=_time_decoder)
+        return cls(data=loaded['data'], metadata=loaded['metadata'], **kwargs)
+
+    def __init__(self, data=None, metadata=None, expiry_delta=timedelta(hours=1), calculate_expiry_on_read=False) -> None:
+        raw = {'metadata': {}, 'data': {}}
+        self._expiry_delta = expiry_delta
+        self._calc_on_read = calculate_expiry_on_read
+        if data is not None:
+            raw['data'] = data.copy()
+
+        if metadata is not None:
+            raw['metadata'] = metadata.copy()
+
+        self._raw = raw
+
+    @property
+    def empty(self) -> bool:
+        return not (self._raw.get('data') and self._raw.get('metadata'))
+
+    @property
+    def created(self) -> datetime:
+        if self.empty:
+            return None
+
+        return self.metadata.get('created')
+
+    @property
+    def expires(self) -> datetime:
+        if self.empty:
+            return None
+
+        if self._calc_on_read:
+            if self.created is None:
+                return None
+
+            return self.created + self._expiry_delta
+        else:
+            return self.metadata.get('expires')
+
+    @property
+    def expired(self) -> bool:
+        expires = self.expires
+        return expires is not None and datetime.utcnow() >= expires
+
+    @property
+    def metadata(self) -> dict:
+        return self._raw['metadata']
+
+    @property
+    def data(self) -> dict:
+        return self._raw['data']
+
+    @data.setter
+    def data(self, value) -> None:
+        self._raw['data'] = value
+        self.metadata['dirty'] = True
+
+    @property
+    def dirty(self) -> bool:
+        return self.metadata.get('dirty', False)
+
+    def update(self, force=False):
+        if not (force or self.dirty):
+            return
+
+        now = datetime.utcnow()
+        self.metadata['created'] = now
+        self.metadata['expires'] = now + self._expiry_delta
+        self.metadata['dirty'] = False
+
+    def _to_serializable_dict(self):
+        o = {
+            'data': self.data,
+            'metadata': self.metadata.copy(),
+        }
+        o['metadata'].pop('dirty')
+        return o
+
+
+class ProxyUpstream:
+    _cache_path = '_cache'
+
+    def __init__(self, repository, upstream_url) -> None:
+        self._repository = repository
+        self._upstream = upstream_url
+
+    def _get_cache(self, request, **kwargs) -> _CacheEntry:
+        path = self._repository / self._cache_path / request.path / 'data.json'
+
+        try:
+            with path.open() as f:
+                return _CacheEntry.from_file(f, **kwargs)
+        except ArtifactoryException:
+            return _CacheEntry(**kwargs)
+
+    def _set_cache(self, request, cache) -> None:
+        from . import DateTimeIsoFormatJSONEncoder
+
+        path = self._repository / self._cache_path / request.path / 'data.json'
+        buffer = StringIO()
+        cache.update()
+        json.dump(cache._to_serializable_dict(), buffer, cls=DateTimeIsoFormatJSONEncoder)
+        buffer.seek(0)
+        path.deploy(buffer)
+        buffer.close()
+
+    def proxy(self, request):
+        cache = self._get_cache(request)
+
+        if cache.empty or cache.expired:
+            req = self._rewrite_to_upstream(request, self._upstream)
+            with requests.Session() as s:
+                try:
+                    resp = s.send(req)
+                    resp.raise_for_status()
+                except requests.exceptions.HTTPError:
+                    infoer = current_app.logger.debug if resp.status_code == C.HTTP_NOT_FOUND else current_app.logger.warning
+                    infoer("Upstream results not available, got HTTP %i: %s", resp.status_code, resp.text)
+                    if cache.expired:
+                        current_app.logger.info(f"Cache hit (expired, upstream error): {request.url}")
+                        return cache.data
+                    # else:
+                        # abort(Response(resp.text, resp.status_code))
+
+
+                else:
+                    current_app.logger.info(f"Cache miss: {request.url}")
+                    data = self._rewrite_upstream_response(resp.json(), request.url_root)
+                    cache.data = data
+                    self._set_cache(request, cache)
+        else:
+            current_app.logger.info(f"Cache hit: {request.url}")
+
+        return cache.data
+
+    def _rewrite_upstream_response(self, response_data, url_root) -> dict:
+        ret = {}
+        for k, v in response_data.items():
+            if isinstance(v, dict):
+                ret[k] = self._rewrite_upstream_response(v, url_root)
+            elif isinstance(v, list):
+                ret[k] = [self._rewrite_upstream_response(d, url_root) if isinstance(d, dict) else d for d in v]
+            elif isinstance(v, str) and v.startswith(self._upstream):
+                if 'api/v1' in v:
+                    continue
+                ret[k] = v.replace(self._upstream, url_root)
+            elif k == 'id':
+                continue
+            else:
+                ret[k] = v
+
+        return ret
+
+    def _rewrite_to_upstream(self, request, upstream_url, prepared=True):
+        this_url = request.url
+        this_root = request.url_root
+        rewritten = this_url.replace(this_root, upstream_url)
+
+        current_app.logger.info(f"Rewriting '{this_url}' to '{rewritten}'")
+
+        headers = {k: v for k, v in request.headers.items() if k not in ['Authorization', 'Host']}
+
+        req = requests.Request(method=request.method, url=rewritten, headers=headers, data=request.data)
+
+        if prepared:
+            prepared = req.prepare()
+            current_app.logger.info(prepared.url)
+            current_app.logger.info(prepared.body)
+            current_app.logger.info(prepared.headers)
+            return prepared
+
+        return req

--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -137,6 +137,21 @@ class ProxyUpstream:
         path.deploy(buffer)
         buffer.close()
 
+    @contextmanager
+    def proxy_download(self, request):
+        req = self._rewrite_to_upstream(request, self._upstream)
+        with requests.Session() as s:
+            try:
+                resp = s.send(req, stream=True)
+                resp.raise_for_status()
+            except:
+                abort(Response(resp.text, resp.status_code))
+            else:
+                try:
+                    yield resp
+                finally:
+                    resp.close()
+
     def proxy(self, request):
         cache = self._get_cache(request)
 

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -61,7 +61,12 @@ def discover_collections(repo, namespace=None, name=None, version=None):
             'filename': p.name,
             'sha256': info.sha256,
             'size': info.size,
-            'download_url': str(p),
+            'download_url': url_for(
+                'download.download',
+                filename=p.name,
+                _external=True,
+            ),
+            # 'download_url': str(p),
             'mime_type': info.mime_type,
             'version': props['version'][0],
             'semver': semver.VersionInfo.parse(props['version'][0]),
@@ -96,7 +101,6 @@ def collected_collections(repo, namespace=None, name=None):
                     col['latest'] = c
 
     return collections
-
 
 
 def _collection_listing(repo, namespace=None, collection=None):

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -25,7 +25,12 @@ def authorize(request, artifactory_path) -> ArtifactoryPath:
 
     return target
 
-
+# TODO: this relies on a paid feature
+# We can work around it by parsing the archives as we upload,
+# and extracting the manifest at that time. We're already now
+# adding the important part (collection_info) as its own
+# property, so all read operations will be able to get it
+# that way in the future.
 def load_manifest_from_artifactory(artifact):
     with urlopen(str(artifact) + '!/MANIFEST.json') as u:
         manifest = json.load(u)

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -105,14 +105,14 @@ def _collection_listing(repo, namespace=None, collection=None):
             'created': latest['created'],
             'modified': latest['modified'],
             'versions_url': url_for(
-                'versions',
+                'api.v2.versions',
                 namespace=latest['namespace']['name'],
                 collection=latest['name'],
                 _external=True,
             ),
             'latest_version': {
                 'href': url_for(
-                    'version',
+                    'api.v2.version',
                     namespace=latest['namespace']['name'],
                     collection=latest['name'],
                     version=latest['version'],

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -7,7 +7,23 @@ import math
 
 from urllib.request import urlopen
 
-from flask import url_for, request
+from flask import url_for, request, current_app
+from artifactory import ArtifactoryPath
+
+
+def authorize(request, artifactory_path) -> ArtifactoryPath:
+    apikey = current_app.config['ARTIFACTORY_API_KEY']
+
+    if current_app.config['USE_GALAXY_KEY'] and (not current_app.config['PREFER_CONFIGURED_KEY'] or not apikey):
+        authorization = request.headers.get('Authorization')
+        if authorization:
+            apikey = authorization.split(' ')[1]
+
+    target = artifactory_path
+    if apikey:
+        target = ArtifactoryPath(target, apikey=apikey)
+
+    return target
 
 
 def load_manifest_from_artifactory(artifact):

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -3,6 +3,7 @@
 
 import json
 import semver
+import math
 
 from urllib.request import urlopen
 
@@ -107,3 +108,8 @@ def _collection_listing(repo, namespace=None, collection=None):
         results.append(result)
 
     return results
+
+
+def lcm(a, b, *more):
+    z = lcm(b, *more) if more else b
+    return abs(a * z) // math.gcd(a, z)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
 [tool.pytest.ini_options]
 minversion = "7.1"
 # addopts = "--docker-compose=artifactory/docker-compose.yml"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = galactory
+version = 0.1.0
+url = https://github.com/briantist/galactory
+author = Brian Scholer
+license = GPLv3+
+license_files = LICENSE
+description = Ansible Galaxy proxy using Artifactory as a backend
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords =
+    ansible
+    galaxy
+    artifactory
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+
+[options]
+zip_safe = True
+include_package_data = True
+python_requires = >= 3.6
+install_requires =
+    dohq-artifactory>=0.8,<0.9
+    Flask>=2.1,<3
+    semver>=2,<3
+    base64io>=1,<2

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,6 +16,12 @@ def app():
 
 
 @pytest.fixture
+def app_request_context(app):
+    with app.app_context(), app.test_request_context():
+        yield
+
+
+@pytest.fixture
 def client(app):
     return app.test_client()
 

--- a/tests/unit/utilities/test_collected_collections.py
+++ b/tests/unit/utilities/test_collected_collections.py
@@ -26,7 +26,7 @@ def test_collected_collections_skip_missing_version(repository, props):
 
 @pytest.mark.parametrize('namespace', [None, 'community', 'briantist', 'fake'])
 @pytest.mark.parametrize('collection', [None, 'whatever', 'hashi_vault', 'fake'])
-def test_collected_collections_any(repository, discover_collections, namespace, collection):
+def test_collected_collections_any(repository, discover_collections, namespace, collection, app_request_context):
     fqcn = None if any([namespace is None, collection is None]) else f"{namespace}.{collection}"
 
     collections = collected_collections(repository, namespace, collection)

--- a/tests/unit/utilities/test_discover_collections.py
+++ b/tests/unit/utilities/test_discover_collections.py
@@ -27,7 +27,7 @@ def test_discover_collections_skip_missing_version(repository, props):
 @pytest.mark.parametrize('namespace', [None, 'community', 'briantist', 'fake'])
 @pytest.mark.parametrize('collection', [None, 'whatever', 'hashi_vault', 'fake'])
 @pytest.mark.parametrize('version', [None, '2.5.0', '3.0.0', '0.1.0', '0.2.0', '0.0.0'])
-def test_discover_collections_any(repository, manifest_loader, namespace, collection, version):
+def test_discover_collections_any(repository, manifest_loader, namespace, collection, version, app_request_context):
     gen = discover_collections(repository, namespace, collection, version)
 
     assert isinstance(gen, GeneratorType)


### PR DESCRIPTION
A lot of big changes here:
* properly license as GPLv3
* setting the API key for Artifactory is not possible directly, optionally via the galaxy token sent with a request, or both
* all requests to artifactory now include the API key if one is available; that makes it possible to use this with repos that are not open anonymously for reads
* all downloads are now proxied through galactory (previously we sent the galaxy client the direct artifactory URL), which should have only a negligible performance impact, but now also enables authenticated downloads possible, and proxying upstreams (next item)
* support for proxying to an upstream galaxy server
  * only tested with _the_ Galaxy, a server that doesn't match its endpoints exactly may not work
  * an upstream that requires authorization to read will not work at this time (no way to configure it, and we strip all authorization from upstream requests to avoid leaking the artifactory key)
  * ensures upstream results are combined with locally available results (not for the general "tell me all the collections path")
  * to make this feasible, we need to cache the upstream results; rather than cache them locally, I've chosen to cache them _inside_ artifactory, to fit the use case of multiple instances of galactory (short lived instances running in CI for example) not hitting upstream throttling
  * when proxying to an upstream, because normal reads now need to write to artifactory, an API key is needed even if the repository is readable anonymously
  * namespaces that should never be proxied upstream can be configured (don't want to be sending a bunch of API requests to galaxy for `your_company.internal_collection` all the time)
  * when collections are downloaded from an upstream, they get uploaded to artifactory first, making them local in subsequent requests (although that should all be transparent)
    * this can enable a scenario where a "trusted" instance, configured with an artifactory API key, and knows all the upstream collections needed, can `ansible-galaxy install` or `ansible-galaxy download` them to a throwaway location, in order to ensure they're available from artifactory
    * other instances can be configured _not_ to proxy upstream, and they will only ever download from what's available in artifactory
    * if they aren't proxying, and the artifactory repo allows anonymous downloads, then no API key will be needed for this
* all uploads (direct or via proxying) now calculate all 3 hashes (MD5, SHA1, SHA256) so that they can be properly verified in Artifactory