### PR TITLE
Configurable server name

### DIFF
--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
     )
     parser.add_argument('--listen-addr', default='0.0.0.0', type=str, help='The IP address to listen on.')
     parser.add_argument('--listen-port', default=5555, type=int, help='The TCP port to listen on.')
+    parser.add_argument('--server-name', type=str, help='The host name and port of the server, as seen from clients. Used for generating links.')
     parser.add_argument('--artifactory-path', type=str, required=True, help='The URL of the path in Artifactory where collections are stored.')
     parser.add_argument('--artifactory-api-key', default=os.environ.get('GALACTORY_ARTIFACTORY_API_KEY'), help='If set, is the API key used to access Artifactory.')
     parser.add_argument('--use-galaxy-key', action='store_true', help='If set, uses the Galaxy token as the Artifactory API key.')
@@ -47,6 +48,7 @@ if __name__ == '__main__':
         ARTIFACTORY_API_KEY=args.artifactory_api_key,
         USE_GALAXY_KEY=args.use_galaxy_key,
         PREFER_CONFIGURED_KEY=args.prefer_configured_key,
+        SERVER_NAME=args.server_name,
     )
 
     print(app.url_map)

--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -170,16 +170,15 @@ class ProxyUpstream:
                     # else:
                         # abort(Response(resp.text, resp.status_code))
 
-
                 else:
                     current_app.logger.info(f"Cache miss: {request.url}")
-                    data = self._rewrite_upstream_response(resp.json(), request.url_root)
+                    data = resp.json()
                     cache.data = data
                     self._set_cache(request, cache)
         else:
             current_app.logger.info(f"Cache hit: {request.url}")
 
-        return cache.data
+        return self._rewrite_upstream_response(cache.data, request.url_root)
 
     def _rewrite_upstream_response(self, response_data, url_root) -> dict:
         ret = {}


### PR DESCRIPTION
Two changes here allowing for more flexible server name use:
* There's now a `--server-name` CLI option if you want to explicitly set the server name; doing so will result in a 404 for any requests whose `Host` header does not match this name.
* Caching of upstream responses now stores the raw upstream response in the cache, and the responses are rewritten upon being read.
  * This is necessary to support multiple running galactory instances with different server names that use the same artifactory backend; otherwise the cache would store the rewritten response of the galactory server that set it, and other instances would return the wrong URLs to their clients.