### PR TITLE
Retries and performance improvements

### DIFF
--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -12,7 +12,7 @@ from artifactory import ArtifactoryException
 from flask import current_app, abort, Response
 
 from . import constants as C
-
+from .utilities import _session_with_retries
 
 class _CacheEntry:
     _raw = {}
@@ -140,7 +140,7 @@ class ProxyUpstream:
     @contextmanager
     def proxy_download(self, request):
         req = self._rewrite_to_upstream(request, self._upstream)
-        with requests.Session() as s:
+        with _session_with_retries() as s:
             try:
                 resp = s.send(req, stream=True)
                 resp.raise_for_status()
@@ -157,7 +157,7 @@ class ProxyUpstream:
 
         if cache.empty or cache.expired:
             req = self._rewrite_to_upstream(request, self._upstream)
-            with requests.Session() as s:
+            with _session_with_retries() as s:
                 try:
                     resp = s.send(req)
                     resp.raise_for_status()

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -45,9 +45,7 @@ def authorize(request, artifactory_path, retry=None) -> ArtifactoryPath:
         auth = XJFrogArtApiAuth(apikey)
 
     session = _session_with_retries(retry=retry, auth=auth)
-    target = ArtifactoryPath(artifactory_path, session=session)
-
-    return target
+    return ArtifactoryPath(artifactory_path, session=session)
 
 
 # TODO: this relies on a paid feature

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -99,7 +99,7 @@ def mock_artifactory_path(mock_artifactory_accessor, virtual_fs_repo):
             ci = self._galactory_get_manifest('collection_info')
 
             return {
-                'collection_info': json.dumps(ci),
+                'collection_info': [json.dumps(ci)],
                 'fqcn': [f"{ci['namespace']}.{ci['name']}"],
                 'namespace': [ci['namespace']],
                 'name': [ci['name']],

--- a/tests/unit/utilities/test_discover_collections.py
+++ b/tests/unit/utilities/test_discover_collections.py
@@ -43,10 +43,10 @@ def test_discover_collections_any(repository, manifest_loader, namespace, collec
     ]):
         assert len(collections) == 0
 
-    assert len(contents) == manifest_loader.call_count
-
-    expected_calls = [mock.call(x) for x in contents]
-    manifest_loader.assert_has_calls(expected_calls, any_order=True)
+    # TODO: we're phasing out the manifest loader, remove later
+    # assert len(contents) == manifest_loader.call_count
+    # expected_calls = [mock.call(x) for x in contents]
+    # manifest_loader.assert_has_calls(expected_calls, any_order=True)
 
     for c in collections:
         assert 'collection_info' in c


### PR DESCRIPTION
Closes #7 
Closes #8 

Related:
- #5 

We now attempt to read the `collection_info` property before trying to read the manifest out of the tarball via artifactory (#5), and we fall back to reading it in case the property doesn't exist. This is just a holdover in case there are any collections in artifactory that were uploaded with the first version of galactory (which probably only affects me). 

**The fallback will be removed in the next version,** so find any of those collections, and if they're upstreams-made-local, maybe just delete them and let them get repopulated. If they're local, republish them.

This reduces a potentially expensive connection.

But I went even further in terms of improving performance. As I've used this it's gotten slower and slower as the number of collections increased, and I realized the reason is that when iterating, even when we know the specific collection and version we want, we're kind of just browsing the list, and for each collection we're asking for a stat and its properties, which are two separate HTTP requests, before we can eliminate the collection as a candidate. This was really slowing things down.

So I've added a fast detection mode, on by default (and not user configurable at this time), that uses the naming convention of the file to try to determine the things we can use to prevent furthe requests and skip quickly.

For example, `briantist-whatever-0.1.0.tar.gz` can be split to `namespace: briantist` and `collection: whatever` and `version: 0.1.0` and that's enough info to not match, we can skip before making any additional requests.

If the collection isn't eliminated with that, we proceed with the rest of the screening as before, except that I've split the `stat` and `properties` requests now, doing stat first, then the conditional that might skip, then ask for properties, then the conditional that might skip on that. So a small improvement there in addition to the above.

In testing, this is a LOT faster, and I think it will also help alleviate some of the connection errors I was seeing that led to #7 and #8.