### PR TITLE
ARM64 container build, change meaning of `latest` docker tag, add branch (`main`) docker tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
     env:
       PYTEST_ADDOPTS: '--color=yes'
     outputs:
-      relver: ${{ steps.sever.outputs.relver }}
+      relver: ${{ steps.setvars.outputs.relver }}
+      branch: ${{ steps.setvars.outputs.branch }}
     steps:
       - uses: actions/checkout@v3
 
@@ -39,13 +40,13 @@ jobs:
       - name: Pytest
         run: pytest tests/
 
-      - name: Set version
-        id: setver
+      - name: Set vars
+        id: setvars
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           VER_TAG=${GITHUB_REF/refs\/tags\/v/}
           echo "::set-output name=relver::${VER_TAG}"
-
+          echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
 
   build:
     needs: [test]
@@ -142,7 +143,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${UPSTREAM}:latest
+            ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && 'latest' || needs.test.outputs.branch }}
             ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }}
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
           # - '3.11-dev'  # test broken:  AttributeError: module 'pathlib' has no attribute '_Accessor'
     env:
       PYTEST_ADDOPTS: '--color=yes'
+    outputs:
+      relver: ${{ steps.sever.outputs.relver }}
     steps:
       - uses: actions/checkout@v3
 
@@ -37,22 +39,40 @@ jobs:
       - name: Pytest
         run: pytest tests/
 
+      - name: Set version
+        id: setver
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          VER_TAG=${GITHUB_REF/refs\/tags\/v/}
+          echo "::set-output name=relver::${VER_TAG}"
+
 
   build:
     needs: [test]
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    outputs:
-      relver: ${{ steps.checkver.outputs.relver }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-      - name: Build container
-        run: docker build -t galactory:latest .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: galactory:latest
+
+      # - name: Build container
+      #   run: docker build -t galactory:latest .
 
       - name: Run container
         run: docker run --rm galactory --help
+
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:
@@ -71,8 +91,7 @@ jobs:
         id: checkver
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          VER_TAG=${GITHUB_REF/refs\/tags\/v/}
-          echo "::set-output name=relver::${VER_TAG}"
+          VER_TAG=${{ needs.test.outputs.relver }}
 
           expected_sdist=galactory-${VER_TAG}.tar.gz
           expected_wheel=galactory-${VER_TAG}-py3-none-any.whl
@@ -91,7 +110,7 @@ jobs:
 
 
   release:
-    needs: [build]
+    needs: [test, build]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
@@ -100,7 +119,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build container
-        run: docker build -t ${UPSTREAM}:latest -t ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.build.outputs.relver || github.sha }} .
+        run: docker build -t ${UPSTREAM}:latest -t ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }} .
 
       - name: Run container
         run: docker run --rm ${UPSTREAM}:latest --help
@@ -134,6 +153,6 @@ jobs:
           fail_on_unmatched_files: true
           files: dist/*
           body: |
-            PyPI: https://pypi.org/project/galactory/${{ needs.build.outputs.relver }}/
-            Container: `ghcr.io/${{ github.repository }}:${{ needs.build.outputs.relver }}`
+            PyPI: https://pypi.org/project/galactory/${{ needs.test.outputs.relver }}/
+            Container: `ghcr.io/${{ github.repository }}:${{ needs.test.outputs.relver }}`
             Browse container tags: https://github.com/briantist/galactory/pkgs/container/galactory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build
+      - name: Build amd64
         uses: docker/build-push-action@v3
         with:
           push: false
           context: .
           load: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: galactory:latest
 
       # - name: Build container
@@ -75,6 +75,14 @@ jobs:
 
       - name: Run container
         run: docker run --rm galactory --help
+
+      - name: Build arm64
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          context: .
+          platforms: linux/arm64
+          tags: galactory:latest
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -63,6 +65,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: false
+          context: .
           platforms: linux/amd64,linux/arm64
           tags: galactory:latest
 
@@ -71,8 +74,6 @@ jobs:
 
       - name: Run container
         run: docker run --rm galactory --help
-
-      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,9 +70,6 @@ jobs:
           platforms: linux/amd64
           tags: galactory:latest
 
-      # - name: Build container
-      #   run: docker build -t galactory:latest .
-
       - name: Run container
         run: docker run --rm galactory --help
 
@@ -148,16 +145,6 @@ jobs:
             ${UPSTREAM}:latest
             ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }}
 
-      # - name: Build container
-      #   run: docker build -t ${UPSTREAM}:latest -t ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }} .
-
-      # - name: Run container
-      #   run: docker run --rm ${UPSTREAM}:latest --help
-
-      # - name: Push to registry
-      #   if: github.event_name == 'push'
-      #   run: docker push --all-tags ${UPSTREAM}
-
       - uses: actions/download-artifact@v3
         with:
           name: dist
@@ -167,8 +154,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295
         with:
-          # TODO: remove: needed to upload initial package manually to get scoped token
-          skip_existing: true
           user: __token__
           password: ${{ secrets.pypi }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,11 +61,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push
+      - name: Build
         uses: docker/build-push-action@v3
         with:
           push: false
           context: .
+          load: true
           platforms: linux/amd64,linux/arm64
           tags: galactory:latest
 
@@ -119,19 +120,35 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build container
-        run: docker build -t ${UPSTREAM}:latest -t ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }} .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-      - name: Run container
-        run: docker run --rm ${UPSTREAM}:latest --help
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to registry
         if: github.event_name == 'push'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Push to registry
-        if: github.event_name == 'push'
-        run: docker push --all-tags ${UPSTREAM}
+      - name: Build & Push
+        uses: docker/build-push-action@v3
+        with:
+          push: ${{ github.event_name == 'push' }}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${UPSTREAM}:latest
+            ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }}
+
+      # - name: Build container
+      #   run: docker build -t ${UPSTREAM}:latest -t ${UPSTREAM}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }} .
+
+      # - name: Run container
+      #   run: docker run --rm ${UPSTREAM}:latest --help
+
+      # - name: Push to registry
+      #   if: github.event_name == 'push'
+      #   run: docker push --all-tags ${UPSTREAM}
 
       - uses: actions/download-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ python3 -m pip install galactory
 ```
 
 ## Container
+
+Latest tagged release:
 ```shell
 docker run --rm ghcr.io/briantist/galactory:latest --help
+```
+
+Latest commit on `main`:
+```shell
+docker run --rm ghcr.io/briantist/galactory:main --help
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = galactory
-version = 0.3.0
+version = 0.3.1
 url = https://github.com/briantist/galactory
 author = Brian Scholer
 license = GPLv3+


### PR DESCRIPTION
Closes #10

- Add ARM64 container builds
- Stop tagging individual pushes as `latest` for docker images
- For pushed git tags, use `latest` tag for docker image
- For other commits, tag container with branch name