### PR TITLE
Improve configuration options (config file(s), environment variables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,43 +9,75 @@ It can also be set up to transparently proxy an upstream Galaxy server, storing 
 This project is _heavily_ inspired by [amanda](https://github.com/sivel/amanda/).
 
 # How to use
-There isn't any proper documentation yet. Here's the help output:
+There isn't any proper documentation yet. The help output is below.
+
+Pulling out this bit about configuration for emphasis:
+
+> Args that start with `--` (eg. `--listen-addr`) can also be set in a config file (`/etc/galactory.d/*.conf` or `~/.galactory/*.conf` or specified via `-c`). Config file syntax allows:
+> - `key=value`
+> - `flag=true`
+> - `stuff=[a,b,c]`
+> (for details, see `DefaultConfigFileParser` syntax at https://github.com/bw2/ConfigArgParse#config-file-syntax).
+>
+> If an arg is specified in more than one place, then commandline values override environment variables which override config file values which override defaults.
+>
+> `defaults < config < environment variables < command line` (last one found wins)
 
 ```text
-usage: python -m galactory [-h] [--listen-addr LISTEN_ADDR] [--listen-port LISTEN_PORT] [--server-name SERVER_NAME]
-                           --artifactory-path ARTIFACTORY_PATH [--artifactory-api-key ARTIFACTORY_API_KEY]
-                           [--use-galaxy-key] [--prefer-configured-key] [--log-file LOG_FILE]
-                           [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--log-headers] [--log-body]
-                           [--proxy-upstream PROXY_UPSTREAM] [-npns NO_PROXY_NAMESPACE]
+usage: python -m galactory [-h] [-c CONFIG] [--listen-addr LISTEN_ADDR]
+                           [--listen-port LISTEN_PORT] [--server-name SERVER_NAME]
+                           --artifactory-path ARTIFACTORY_PATH
+                           [--artifactory-api-key ARTIFACTORY_API_KEY] [--use-galaxy-key]
+                           [--prefer-configured-key] [--log-file LOG_FILE]
+                           [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--log-headers]
+                           [--log-body] [--proxy-upstream PROXY_UPSTREAM]
+                           [-npns NO_PROXY_NAMESPACE]
 
-galactory is a partial Ansible Galaxy proxy that uploads and downloads collections, using an Artifactory generic
-repository as its backend.
+galactory is a partial Ansible Galaxy proxy that uploads and downloads collections, using an
+Artifactory generic repository as its backend.
 
 optional arguments:
   -h, --help            show this help message and exit
+  -c CONFIG, --config CONFIG
+                        The path to a config file. [env var: GALACTORY_CONFIG]
   --listen-addr LISTEN_ADDR
-                        The IP address to listen on.
+                        The IP address to listen on. [env var: GALACTORY_LISTEN_ADDR]
   --listen-port LISTEN_PORT
-                        The TCP port to listen on.
+                        The TCP port to listen on. [env var: GALACTORY_LISTEN_PORT]
   --server-name SERVER_NAME
-                        The host name and port of the server, as seen from clients. Used for generating links.
+                        The host name and port of the server, as seen from clients. Used for
+                        generating links. [env var: GALACTORY_SERVER_NAME]
   --artifactory-path ARTIFACTORY_PATH
-                        The URL of the path in Artifactory where collections are stored.
+                        The URL of the path in Artifactory where collections are stored. [env var:
+                        GALACTORY_ARTIFACTORY_PATH]
   --artifactory-api-key ARTIFACTORY_API_KEY
-                        If set, is the API key used to access Artifactory.
-  --use-galaxy-key      If set, uses the Galaxy token as the Artifactory API key.
+                        If set, is the API key used to access Artifactory. [env var:
+                        GALACTORY_ARTIFACTORY_API_KEY]
+  --use-galaxy-key      If set, uses the Galaxy token as the Artifactory API key. [env var:
+                        GALACTORY_USE_GALAXY_KEY]
   --prefer-configured-key
-                        If set, prefer the confgured Artifactory key over the Galaxy token.
-  --log-file LOG_FILE   If set, logging will go to this file instead of the console.
+                        If set, prefer the confgured Artifactory key over the Galaxy token. [env
+                        var: GALACTORY_PREFER_CONFIGURED_KEY]
+  --log-file LOG_FILE   If set, logging will go to this file instead of the console. [env var:
+                        GALACTORY_LOG_FILE]
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        The desired logging level.
-  --log-headers         Log the headers of every request (DEBUG level only).
-  --log-body            Log the body of every request (DEBUG level only).
+                        The desired logging level. [env var: GALACTORY_LOG_LEVEL]
+  --log-headers         Log the headers of every request (DEBUG level only). [env var:
+                        GALACTORY_LOG_HEADERS]
+  --log-body            Log the body of every request (DEBUG level only). [env var:
+                        GALACTORY_LOG_BODY]
   --proxy-upstream PROXY_UPSTREAM
-                        If set, then find, pull and cache results from the specified galaxy server in addition to
-                        local.
+                        If set, then find, pull and cache results from the specified galaxy server
+                        in addition to local. [env var: GALACTORY_PROXY_UPSTREAM]
   -npns NO_PROXY_NAMESPACE, --no-proxy-namespace NO_PROXY_NAMESPACE
-                        Requests for this namespace should never be proxied. Can be specified multiple times.
+                        Requests for this namespace should never be proxied. Can be specified
+                        multiple times. [env var: GALACTORY_NO_PROXY_NAMESPACE]
+
+Args that start with '--' (eg. --listen-addr) can also be set in a config file
+(/etc/galactory.d/*.conf or ~/.galactory/*.conf or specified via -c). Config file syntax allows:
+key=value, flag=true, stuff=[a,b,c] (for details, see syntax at https://goo.gl/R74nmi). If an arg
+is specified in more than one place, then commandline values override environment variables which
+override config file values which override defaults.
 ```
 
 ## Install

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
         ),
         default_config_files=['/etc/galactory.d/*.conf', '~/.galactory/*.conf'],
     )
-    parser.add_argument('-c', '--config', required=False, is_config_file=True, help='The path to a config file.')
+    parser.add_argument('-c', '--config', required=False, is_config_file=True, env_var='GALACTORY_CONFIG', help='The path to a config file.')
     parser.add_argument('--listen-addr', default='0.0.0.0', type=str, env_var='GALACTORY_LISTEN_ADDR', help='The IP address to listen on.')
     parser.add_argument('--listen-port', default=5555, type=int, env_var='GALACTORY_LISTEN_PORT', help='The TCP port to listen on.')
     parser.add_argument('--server-name', type=str, env_var='GALACTORY_SERVER_NAME', help='The host name and port of the server, as seen from clients. Used for generating links.')

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2022 Brian Scholer (@briantist)
 
-import os
 import logging
 from configargparse import ArgParser
 from artifactory import ArtifactoryPath
@@ -16,25 +15,28 @@ if __name__ == '__main__':
             'galactory is a partial Ansible Galaxy proxy that uploads and downloads collections, '
             'using an Artifactory generic repository as its backend.'
         ),
+        default_config_files=['/etc/galactory.d/*.conf', '~/.galactory/*.conf'],
     )
-    parser.add_argument('--listen-addr', default='0.0.0.0', type=str, help='The IP address to listen on.')
-    parser.add_argument('--listen-port', default=5555, type=int, help='The TCP port to listen on.')
-    parser.add_argument('--server-name', type=str, help='The host name and port of the server, as seen from clients. Used for generating links.')
-    parser.add_argument('--artifactory-path', type=str, required=True, help='The URL of the path in Artifactory where collections are stored.')
-    parser.add_argument('--artifactory-api-key', default=os.environ.get('GALACTORY_ARTIFACTORY_API_KEY'), help='If set, is the API key used to access Artifactory.')
-    parser.add_argument('--use-galaxy-key', action='store_true', help='If set, uses the Galaxy token as the Artifactory API key.')
-    parser.add_argument('--prefer-configured-key', action='store_true', help='If set, prefer the confgured Artifactory key over the Galaxy token.')
-    parser.add_argument('--log-file', type=str, help='If set, logging will go to this file instead of the console.')
+    parser.add_argument('-c', '--config', required=False, is_config_file=True, help='The path to a config file.')
+    parser.add_argument('--listen-addr', default='0.0.0.0', type=str, env_var='GALACTORY_LISTEN_ADDR', help='The IP address to listen on.')
+    parser.add_argument('--listen-port', default=5555, type=int, env_var='GALACTORY_LISTEN_PORT', help='The TCP port to listen on.')
+    parser.add_argument('--server-name', type=str, env_var='GALACTORY_SERVER_NAME', help='The host name and port of the server, as seen from clients. Used for generating links.')
+    parser.add_argument('--artifactory-path', type=str, required=True, env_var='GALACTORY_ARTIFACTORY_PATH', help='The URL of the path in Artifactory where collections are stored.')
+    parser.add_argument('--artifactory-api-key', type=str, env_var='GALACTORY_ARTIFACTORY_API_KEY', help='If set, is the API key used to access Artifactory.')
+    parser.add_argument('--use-galaxy-key', action='store_true', env_var='GALACTORY_USE_GALAXY_KEY', help='If set, uses the Galaxy token as the Artifactory API key.')
+    parser.add_argument('--prefer-configured-key', action='store_true', env_var='GALACTORY_PREFER_CONFIGURED_KEY', help='If set, prefer the confgured Artifactory key over the Galaxy token.')
+    parser.add_argument('--log-file', type=str, env_var='GALACTORY_LOG_FILE', help='If set, logging will go to this file instead of the console.')
     parser.add_argument(
         '--log-level',
         type=str.upper,
+        env_var='GALACTORY_LOG_LEVEL',
         default='INFO',
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], help='The desired logging level.',
     )
-    parser.add_argument('--log-headers', action='store_true', help='Log the headers of every request (DEBUG level only).')
-    parser.add_argument('--log-body', action='store_true', help='Log the body of every request (DEBUG level only).')
-    parser.add_argument('--proxy-upstream', type=lambda x: str(x).rstrip('/') + '/', help='If set, then find, pull and cache results from the specified galaxy server in addition to local.')
-    parser.add_argument('-npns', '--no-proxy-namespace', action='append', default=[], help='Requests for this namespace should never be proxied. Can be specified multiple times.')
+    parser.add_argument('--log-headers', action='store_true', env_var='GALACTORY_LOG_HEADERS', help='Log the headers of every request (DEBUG level only).')
+    parser.add_argument('--log-body', action='store_true', env_var='GALACTORY_LOG_BODY', help='Log the body of every request (DEBUG level only).')
+    parser.add_argument('--proxy-upstream', type=lambda x: str(x).rstrip('/') + '/', env_var='GALACTORY_PROXY_UPSTREAM', help='If set, then find, pull and cache results from the specified galaxy server in addition to local.')
+    parser.add_argument('-npns', '--no-proxy-namespace', action='append', default=[], env_var='GALACTORY_NO_PROXY_NAMESPACE', help='Requests for this namespace should never be proxied. Can be specified multiple times.')
     args = parser.parse_args()
 
     logging.basicConfig(filename=args.log_file, level=args.log_level)

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -3,14 +3,14 @@
 
 import os
 import logging
-from argparse import ArgumentParser
+from configargparse import ArgParser
 from artifactory import ArtifactoryPath
 
 from . import create_app
 
 
 if __name__ == '__main__':
-    parser = ArgumentParser(
+    parser = ArgParser(
         prog='python -m galactory',
         description=(
             'galactory is a partial Ansible Galaxy proxy that uploads and downloads collections, '

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ dohq-artifactory>=0.8,<0.9
 Flask>=2.1,<3
 semver>=2,<3
 base64io>=1,<2
+ConfigArgParse>=1.5,<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,4 @@ install_requires =
     Flask>=2.1,<3
     semver>=2,<3
     base64io>=1,<2
+    ConfigArgParse>=1.5,<2


### PR DESCRIPTION
- Switch to [`ConfigArgParse`](https://github.com/bw2/ConfigArgParse) to get native support for config files and env vars
- All options have environment variables defined now
- Default config paths are `/etc/galactory.d/*.conf` and `~/.galactory/*.conf`