### PR TITLE
Cache configurability - expiry time, read/write controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ usage: python -m galactory [-h] [-c CONFIG] [--listen-addr LISTEN_ADDR]
                            [--prefer-configured-key] [--log-file LOG_FILE]
                            [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--log-headers]
                            [--log-body] [--proxy-upstream PROXY_UPSTREAM]
-                           [-npns NO_PROXY_NAMESPACE]
+                           [-npns NO_PROXY_NAMESPACE] [--cache-minutes CACHE_MINUTES]
+                           [--cache-read CACHE_READ] [--cache-write CACHE_WRITE]
 
 galactory is a partial Ansible Galaxy proxy that uploads and downloads collections, using an
 Artifactory generic repository as its backend.
@@ -48,30 +49,40 @@ optional arguments:
                         The host name and port of the server, as seen from clients. Used for
                         generating links. [env var: GALACTORY_SERVER_NAME]
   --artifactory-path ARTIFACTORY_PATH
-                        The URL of the path in Artifactory where collections are stored. [env var:
-                        GALACTORY_ARTIFACTORY_PATH]
+                        The URL of the path in Artifactory where collections are stored.
+                        [env var: GALACTORY_ARTIFACTORY_PATH]
   --artifactory-api-key ARTIFACTORY_API_KEY
-                        If set, is the API key used to access Artifactory. [env var:
-                        GALACTORY_ARTIFACTORY_API_KEY]
-  --use-galaxy-key      If set, uses the Galaxy token as the Artifactory API key. [env var:
-                        GALACTORY_USE_GALAXY_KEY]
+                        If set, is the API key used to access Artifactory.
+                        [env var: GALACTORY_ARTIFACTORY_API_KEY]
+  --use-galaxy-key      If set, uses the Galaxy token as the Artifactory API key.
+                        [env var: GALACTORY_USE_GALAXY_KEY]
   --prefer-configured-key
-                        If set, prefer the confgured Artifactory key over the Galaxy token. [env
-                        var: GALACTORY_PREFER_CONFIGURED_KEY]
-  --log-file LOG_FILE   If set, logging will go to this file instead of the console. [env var:
-                        GALACTORY_LOG_FILE]
+                        If set, prefer the confgured Artifactory key over the Galaxy token.
+                        [env var: GALACTORY_PREFER_CONFIGURED_KEY]
+  --log-file LOG_FILE   If set, logging will go to this file instead of the console.
+                        [env var: GALACTORY_LOG_FILE]
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         The desired logging level. [env var: GALACTORY_LOG_LEVEL]
-  --log-headers         Log the headers of every request (DEBUG level only). [env var:
-                        GALACTORY_LOG_HEADERS]
-  --log-body            Log the body of every request (DEBUG level only). [env var:
-                        GALACTORY_LOG_BODY]
+  --log-headers         Log the headers of every request (DEBUG level only).
+                        [env var: GALACTORY_LOG_HEADERS]
+  --log-body            Log the body of every request (DEBUG level only).
+                        [env var: GALACTORY_LOG_BODY]
   --proxy-upstream PROXY_UPSTREAM
                         If set, then find, pull and cache results from the specified galaxy server
                         in addition to local. [env var: GALACTORY_PROXY_UPSTREAM]
   -npns NO_PROXY_NAMESPACE, --no-proxy-namespace NO_PROXY_NAMESPACE
                         Requests for this namespace should never be proxied. Can be specified
                         multiple times. [env var: GALACTORY_NO_PROXY_NAMESPACE]
+  --cache-minutes CACHE_MINUTES
+                        The time period that a cache entry should be considered valid.
+                        [env var: GALACTORY_CACHE_MINUTES]
+  --cache-read CACHE_READ
+                        Look for upsteam caches and use their values.
+                        [env var: GALACTORY_CACHE_READ]
+  --cache-write CACHE_WRITE
+                        Populate the upstream cache in Artifactory. Should be false when no API key is
+                        provided or the key has no permission to write.
+                        [env var: GALACTORY_CACHE_WRITE]
 
 Args that start with '--' (eg. --listen-addr) can also be set in a config file
 (/etc/galactory.d/*.conf or ~/.galactory/*.conf or specified via -c). Config file syntax allows:

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -53,5 +53,4 @@ if __name__ == '__main__':
         SERVER_NAME=args.server_name,
     )
 
-    print(app.url_map)
     app.run(args.listen_addr, args.listen_port, threaded=True)

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -57,6 +57,9 @@ if __name__ == '__main__':
     parser.add_argument('--log-body', action='store_true', env_var='GALACTORY_LOG_BODY', help='Log the body of every request (DEBUG level only).')
     parser.add_argument('--proxy-upstream', type=lambda x: str(x).rstrip('/') + '/', env_var='GALACTORY_PROXY_UPSTREAM', help='If set, then find, pull and cache results from the specified galaxy server in addition to local.')
     parser.add_argument('-npns', '--no-proxy-namespace', action='append', default=[], env_var='GALACTORY_NO_PROXY_NAMESPACE', help='Requests for this namespace should never be proxied. Can be specified multiple times.')
+    parser.add_argument('--cache-minutes', default=60, type=int, env_var='GALACTORY_CACHE_MINUTES', help='The time period that a cache entry should be considered valid.')
+    parser.add_argument('--cache-read', action=_StrBool, default=True, env_var='GALACTORY_CACHE_READ', help='Look for upsteam caches and use their values.')
+    parser.add_argument('--cache-write', action=_StrBool, default=True, env_var='GALACTORY_CACHE_WRITE', help='Populate the upstream cache in Artifactory. Should be false when no API key is provided or the key has no permission to write.')
     args = parser.parse_args()
 
     logging.basicConfig(filename=args.log_file, level=args.log_level)
@@ -71,6 +74,9 @@ if __name__ == '__main__':
         USE_GALAXY_KEY=args.use_galaxy_key,
         PREFER_CONFIGURED_KEY=args.prefer_configured_key,
         SERVER_NAME=args.server_name,
+        CACHE_MINUTES=args.cache_minutes,
+        CACHE_READ=args.cache_read,
+        CACHE_WRITE=args.cache_write,
     )
 
     app.run(args.listen_addr, args.listen_port, threaded=True)

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -2,10 +2,30 @@
 # (c) 2022 Brian Scholer (@briantist)
 
 import logging
-from configargparse import ArgParser
+from configargparse import ArgParser, ArgumentError, Action
 from artifactory import ArtifactoryPath
 
 from . import create_app
+
+
+# TODO: when py3.8 support is dropped, switch to using argparse.BooleanOptionalAction
+class _StrBool(Action):
+    FALSES = {'false', '0', 'no'}
+    TRUES = {'true', '1', 'yes'}
+
+    def _booler(self, value):
+        if isinstance(value, bool):
+            return value
+
+        if value.lower() in self.FALSES:
+            return False
+        if value.lower() in self.TRUES:
+            return True
+
+        raise ArgumentError(self, f"Expecting 'true', 'false', 'yes', 'no', '1' or '0', but got '{value}'")
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, self._booler(values))
 
 
 if __name__ == '__main__':

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -33,10 +33,13 @@ def collection(namespace, collection):
     repository = authorize(request, current_app.config['ARTIFACTORY_PATH'])
     upstream = current_app.config['PROXY_UPSTREAM']
     no_proxy = current_app.config['NO_PROXY_NAMESPACES']
+    cache_minutes = current_app.config['CACHE_MINUTES']
+    cache_read = current_app.config['CACHE_READ']
+    cache_write = current_app.config['CACHE_WRITE']
 
     upstream_result = None
     if upstream and (not no_proxy or namespace not in no_proxy):
-        proxy = ProxyUpstream(repository, upstream)
+        proxy = ProxyUpstream(repository, upstream, cache_read, cache_write, cache_minutes)
         upstream_result = proxy.proxy(request)
 
     results = _collection_listing(repository, namespace, collection)
@@ -66,10 +69,13 @@ def versions(namespace, collection):
     repository = authorize(request, current_app.config['ARTIFACTORY_PATH'])
     upstream = current_app.config['PROXY_UPSTREAM']
     no_proxy = current_app.config['NO_PROXY_NAMESPACES']
+    cache_minutes = current_app.config['CACHE_MINUTES']
+    cache_read = current_app.config['CACHE_READ']
+    cache_write = current_app.config['CACHE_WRITE']
 
     upstream_result = None
     if upstream and (not no_proxy or namespace not in no_proxy):
-        proxy = ProxyUpstream(repository, upstream)
+        proxy = ProxyUpstream(repository, upstream, cache_read, cache_write, cache_minutes)
         upstream_result = proxy.proxy(request)
 
     collections = collected_collections(repository, namespace=namespace, name=collection)
@@ -117,12 +123,15 @@ def version(namespace, collection, version):
     repository = authorize(request, current_app.config['ARTIFACTORY_PATH'])
     upstream = current_app.config['PROXY_UPSTREAM']
     no_proxy = current_app.config['NO_PROXY_NAMESPACES']
+    cache_minutes = current_app.config['CACHE_MINUTES']
+    cache_read = current_app.config['CACHE_READ']
+    cache_write = current_app.config['CACHE_WRITE']
 
     try:
         info = next(discover_collections(repository, namespace=namespace, name=collection, version=version))
     except StopIteration:
         if upstream and (not no_proxy or namespace not in no_proxy):
-            proxy = ProxyUpstream(repository, upstream)
+            proxy = ProxyUpstream(repository, upstream, cache_read, cache_write, cache_minutes)
             upstream_result = proxy.proxy(request)
             return jsonify(upstream_result)
         else:

--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -130,12 +130,11 @@ class ProxyUpstream:
         from . import DateTimeIsoFormatJSONEncoder
 
         path = self._repository / self._cache_path / request.path / 'data.json'
-        buffer = StringIO()
-        cache.update()
-        json.dump(cache._to_serializable_dict(), buffer, cls=DateTimeIsoFormatJSONEncoder)
-        buffer.seek(0)
-        path.deploy(buffer)
-        buffer.close()
+        with StringIO() as buffer:
+            cache.update()
+            json.dump(cache._to_serializable_dict(), buffer, cls=DateTimeIsoFormatJSONEncoder)
+            buffer.seek(0)
+            path.deploy(buffer)
 
     @contextmanager
     def proxy_download(self, request):

--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -34,7 +34,7 @@ class _CacheEntry:
         loaded = json.load(f, object_pairs_hook=_time_decoder)
         return cls(data=loaded['data'], metadata=loaded['metadata'], **kwargs)
 
-    def __init__(self, data=None, metadata=None, expiry_delta=timedelta(hours=1), calculate_expiry_on_read=False) -> None:
+    def __init__(self, expiry_delta, data=None, metadata=None, calculate_expiry_on_read=True) -> None:
         raw = {'metadata': {}, 'data': {}}
         self._expiry_delta = expiry_delta
         self._calc_on_read = calculate_expiry_on_read
@@ -113,20 +113,33 @@ class _CacheEntry:
 class ProxyUpstream:
     _cache_path = '_cache'
 
-    def __init__(self, repository, upstream_url) -> None:
+    def __init__(self, repository, upstream_url, read_cache, write_cache, cache_expiry_minutes) -> None:
         self._repository = repository
         self._upstream = upstream_url
+        self._read_cache = read_cache
+        self._write_cache = write_cache
+        self._cache_expiry_delta = timedelta(minutes=cache_expiry_minutes)
 
-    def _get_cache(self, request, **kwargs) -> _CacheEntry:
+
+    def _get_cache(self, request, expiry_delta=None, **kwargs) -> _CacheEntry:
         path = self._repository / self._cache_path / request.path / 'data.json'
+
+        if expiry_delta is None:
+            expiry_delta = self._cache_expiry_delta
+
+        if not self._read_cache:
+            return _CacheEntry(expiry_delta=expiry_delta, **kwargs)
 
         try:
             with path.open() as f:
-                return _CacheEntry.from_file(f, **kwargs)
+                return _CacheEntry.from_file(f, expiry_delta=expiry_delta, **kwargs)
         except ArtifactoryException:
-            return _CacheEntry(**kwargs)
+            return _CacheEntry(expiry_delta=expiry_delta, **kwargs)
 
     def _set_cache(self, request, cache) -> None:
+        if not self._write_cache:
+            return
+
         from . import DateTimeIsoFormatJSONEncoder
 
         path = self._repository / self._cache_path / request.path / 'data.json'
@@ -170,10 +183,14 @@ class ProxyUpstream:
                         # abort(Response(resp.text, resp.status_code))
 
                 else:
-                    current_app.logger.info(f"Cache miss: {request.url}")
+                    if self._read_cache:
+                        current_app.logger.info(f"Cache miss: {request.url}")
+
                     data = resp.json()
                     cache.data = data
-                    self._set_cache(request, cache)
+
+                    if self._write_cache:
+                        self._set_cache(request, cache)
         else:
             current_app.logger.info(f"Cache hit: {request.url}")
 


### PR DESCRIPTION
Closes #4 

- Allows for configuring that cache expiry in minutes (previously was hardcoded at 1 hour. now defaults to 60 minutes)
- Internal change to cache expiration calculation:
  - when cache is written, the expiration is also written, using the expiry time of the writer
  - reading cache had the ability to calculate whether cache was expired based on local expiry delta + cache creation time, but defaulted to just using the written time
  - this didn't matter when the time was hardcoded: all clients used the same
  - this behavior has been switched to always calculate (for now, it could be configurable later)
  - this means that now, expiry times are still written like before (based on the writer's configuration), but reads always calculate based on the reader's configured expiry time
  - this allows for a reader to decide to trust cached values for a different amount of time than the instance that wrote it
  - a long-running central instance might be set to use a 60 minute expiry time, while a local instance you run on your workstation with a slow connection, where freshness is not that important, could be set to use a 1440 minute expiration; with other writers updating the caches more frequently, it could continually result in not needing to contact the upstream
- Whether to (attempt to) read and write to the cache is now independently configurable:
  - Setting `--cache-read` to `true` (the default) means that caches will be read and the values used, while setting it to `false` will always proxy to an upstream without regard for cached values
  - Setting `--cache-write` to `true` (the default) means that when a request is proxied upstream, the results will be cached (written to Artifactory) so that this or other instances configured to read from cache can avoid contacting the upstream for that request. Setting it to `false` will not write upstream responses to the cache. 
  - Setting `--cache-write` to `false` can be especially useful if proxying to an upstream is desired without setting an Artifactory API key (when reads to Artifactory don't require authentication), as this allows for full upstream support without supplying any authentication/secrets.
  - Notes about "cache" nomenclature and behavior with downloads:
    - previously, all downloads from an upstream (the collection doesn't exist in Artifactory yet) resulted in galactory downloading the collection, uploading it to Artifactory, and then streaming the result from a new download from Artifactory
    - Future requests would always serve that file from Artifactory (since it now exists as a "local" collection basically)
    - Those local collections that came from an upstream are not distinguishable from ones intentionally directly uploaded, and do not count as "cached"; as a result `--cache-read=false` does not affect that behavior (a download of a collection will be served from Artifactory if that's where it exists)
    - While those written-from-upstream collections do not count as "cached", `--cache-write=false` will necessarily result in an upstream collection that doesn't exist in Artifactory _not_ being uploaded to Artifactory, but streamed directly from the upstream

