### PR TITLE
Replace manifest loading from Artifactory

### DIFF
--- a/changelogs/fragments/5-manifest-destiny.yml
+++ b/changelogs/fragments/5-manifest-destiny.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - manifest loading - galactory no longer uses Artifactory's "Archive Entry Download" endpoint, removing the need to use a pro license or greater (https://github.com/briantist/galactory/issues/5, https://github.com/briantist/galactory/pull/16).

--- a/galactory/download/download.py
+++ b/galactory/download/download.py
@@ -34,6 +34,7 @@ def download(filename):
             if not cache_write:
                 return send_file(tmp.handle, as_attachment=True, download_name=filename, etag=False)
 
-            _, _, stat = upload_collection_from_hashed_tempfile(artifact, tmp, return_stat=True)
+            upload_collection_from_hashed_tempfile(artifact, tmp, return_stat=True)
+            stat = artifact.stat()
 
     return send_file(artifact.open(), as_attachment=True, download_name=artifact.name, last_modified=stat.mtime, etag=False)

--- a/galactory/download/download.py
+++ b/galactory/download/download.py
@@ -34,7 +34,7 @@ def download(filename):
             if not cache_write:
                 return send_file(tmp.handle, as_attachment=True, download_name=filename, etag=False)
 
-            upload_collection_from_hashed_tempfile(artifact, tmp, return_stat=True)
+            upload_collection_from_hashed_tempfile(artifact, tmp)
             stat = artifact.stat()
 
     return send_file(artifact.open(), as_attachment=True, download_name=artifact.name, last_modified=stat.mtime, etag=False)

--- a/galactory/download/download.py
+++ b/galactory/download/download.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 # (c) 2022 Brian Scholer (@briantist)
 
-import json
-
-from flask import abort, request, current_app, send_file, Response
-from artifactory import ArtifactoryException
+from flask import abort, request, current_app, send_file
 
 from . import bp as dl
 from .. import constants as C
-from ..utilities import load_manifest_from_archive, authorize, _chunk_to_temp
+from ..utilities import authorize, _chunk_to_temp, upload_collection_from_hashed_tempfile
 from ..upstream import ProxyUpstream
 
 
@@ -37,32 +34,6 @@ def download(filename):
             if not cache_write:
                 return send_file(tmp.handle, as_attachment=True, download_name=filename, etag=False)
 
-            try:
-                manifest = load_manifest_from_archive(tmp.handle)
-            except Exception:
-                abort(Response("Error loading manifest from collection archive.", C.HTTP_INTERNAL_SERVER_ERROR))
-            else:
-                tmp.handle.seek(0)
-                ci = manifest['collection_info']
-                props = {
-                    'collection_info': json.dumps(ci),
-                    'namespace': ci['namespace'],
-                    'name': ci['name'],
-                    'version': ci['version'],
-                    'fqcn': f"{ci['namespace']}.{ci['name']}"
-                }
-
-            try:
-                artifact.deploy(tmp.handle, md5=tmp.md5, sha1=tmp.sha1, sha256=tmp.sha256)  # parameters=props
-                # we can't use parameters=props here because Artifactory rejects quote characters
-                # in their matrix params, and that's not compatible with collection_info because
-                # it's JSON, so we'll still have to set the properties as a separate request :(
-            except ArtifactoryException as exc:
-                cause = exc.__cause__
-                current_app.logger.debug(cause)
-                abort(Response(cause.response.text, cause.response.status_code))
-            else:
-                artifact.properties = props
-                stat = artifact.stat()
+            _, _, stat = upload_collection_from_hashed_tempfile(artifact, tmp, return_stat=True)
 
     return send_file(artifact.open(), as_attachment=True, download_name=artifact.name, last_modified=stat.mtime, etag=False)

--- a/galactory/download/download.py
+++ b/galactory/download/download.py
@@ -35,6 +35,7 @@ def download(filename):
                 return send_file(tmp.handle, as_attachment=True, download_name=filename, etag=False)
 
             upload_collection_from_hashed_tempfile(artifact, tmp)
-            stat = artifact.stat()
+
+        stat = artifact.stat()
 
     return send_file(artifact.open(), as_attachment=True, download_name=artifact.name, last_modified=stat.mtime, etag=False)

--- a/galactory/iter_tar.py
+++ b/galactory/iter_tar.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# (c) 2020 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+
+#     (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this routine lovingly copied from:
+# https://github.com/sivel/amanda/commit/ca3f59ffbe2801c230151aba342157b337c98a24
+
+import sys
+import tarfile
+
+
+ENCODING = sys.getfilesystemencoding()
+
+
+def iter_tar(f):
+    while True:
+        header = f.read(512)
+        if not header:
+            break
+
+        typ = header[156:157]
+        name = tarfile.nts(header[0:100], ENCODING, 'surrogateescape')
+        prefix = tarfile.nts(header[345:500], ENCODING, 'surrogateescape')
+
+        if prefix and typ not in tarfile.GNU_TYPES:
+            name = f'{prefix}/{name}'
+
+        if not name:
+            continue
+
+        size = tarfile.nti(header[124:136])
+        if size:
+            contents = tarfile.nts(f.read(size), ENCODING, 'surrogateescape')
+        else:
+            contents = None
+
+        if name != '././@PaxHeader':
+            yield name, contents
+
+        mod = f.tell() % 512
+        if mod:
+            f.seek(512 - mod, 1)

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -7,6 +7,8 @@ import math
 import hashlib
 import gzip
 
+from typing import Any
+
 from tempfile import SpooledTemporaryFile
 from urllib.request import urlopen
 from urllib3 import Retry
@@ -221,7 +223,7 @@ def _chunk_to_temp(fsrc, iterator=None, spool_size=5*1024*1024, seek_to_zero=Tru
     return HashedTempFile(tmp, md5sum.hexdigest(), sha1sum.hexdigest(),  sha256sum.hexdigest(), close=close)
 
 
-def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: HashedTempFile, return_stat=False):
+def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: HashedTempFile) -> dict[str, Any]:
     stat = None
 
     try:
@@ -249,7 +251,5 @@ def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: H
         abort(Response(cause.response.text, cause.response.status_code))
     else:
         artifact.properties = props
-        if return_stat:
-            stat = artifact.stat()
 
-    return (artifact, props, stat)
+    return props

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -229,7 +229,6 @@ def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: H
     except Exception:
         abort(Response("Error loading manifest from collection archive.", C.HTTP_INTERNAL_SERVER_ERROR))
     else:
-        tmpfile.handle.seek(0)
         ci = manifest['collection_info']
         props = {
             'collection_info': json.dumps(ci),

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -224,8 +224,6 @@ def _chunk_to_temp(fsrc, iterator=None, spool_size=5*1024*1024, seek_to_zero=Tru
 
 
 def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: HashedTempFile) -> Dict[str, Any]:
-    stat = None
-
     try:
         manifest = load_manifest_from_archive(tmpfile.handle)
     except Exception:

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -85,16 +85,10 @@ def discover_collections(repo, namespace=None, name=None, version=None, fast_det
             continue
 
         props = p.properties
-        if not props.get('version'): # TODO: change to collection_info
+        if not props.get('collection_info'):
             continue
 
-        if 'collection_info' in props:
-            collection_info = json.loads(props['collection_info'][0])
-        else:
-            raise ValueError
-            # fallback for now just in case, we expect this never to be hit
-            # TODO: remove in the next version
-            # collection_info = load_manifest_from_artifactory(p)['collection_info']
+        collection_info = json.loads(props['collection_info'][0])
 
         coldata = {
             'collection_info': collection_info,
@@ -111,7 +105,6 @@ def discover_collections(repo, namespace=None, name=None, version=None, fast_det
                 filename=p.name,
                 _external=True,
             ),
-            # 'download_url': str(p),
             'mime_type': info.mime_type,
             'version': props['version'][0],
             'semver': semver.VersionInfo.parse(props['version'][0]),

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -7,7 +7,7 @@ import math
 import hashlib
 import gzip
 
-from typing import Any
+from typing import Dict, Any
 
 from tempfile import SpooledTemporaryFile
 from urllib.request import urlopen
@@ -223,7 +223,7 @@ def _chunk_to_temp(fsrc, iterator=None, spool_size=5*1024*1024, seek_to_zero=Tru
     return HashedTempFile(tmp, md5sum.hexdigest(), sha1sum.hexdigest(),  sha256sum.hexdigest(), close=close)
 
 
-def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: HashedTempFile) -> dict[str, Any]:
+def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: HashedTempFile) -> Dict[str, Any]:
     stat = None
 
     try:

--- a/tests/unit/utilities/conftest.py
+++ b/tests/unit/utilities/conftest.py
@@ -14,7 +14,7 @@ def manifest_loader():
 
     loader = mock.Mock(wraps=_load)
 
-    with mock.patch('galactory.utilities.load_manifest_from_artifactory', loader):
+    with mock.patch('galactory.utilities.load_manifest_from_archive', loader):
         yield loader
 
 


### PR DESCRIPTION
Closes #5

~This is still a WIP, some things to clean up, and I want to generalize the upload code that's mostly duplicated between direct uploads and uploads-on-proxied-downloads.~

Completely replaces the loading of the manifest from artifactory's archive file extraction.

Instead we ~borrowed~ stole the parsing from amanda (https://github.com/sivel/amanda/commit/ca3f59ffbe2801c230151aba342157b337c98a24), and we now take the manifest out of the collection archive itself while it's local.

This solves two things for us:
1. We stop relying on a paid feature of artifactory (#5), which:
   1. Lets people on Artifactory OSS make better use of galactory
   1. Brings us closer to actually writing and running integration tests for this project (#6)
1. (minor) it stops skewing the downloads count in Artifactory -- this direct reading of files within archives seems increment the download count. In fact, #9 reduced most of these requests by looking for the `collection_info` property before reading into the archive; before that change my downloads were in the 5 or 6 figures, because every iteration was triggering a "download". But this PR will reduce the last of those phantom downloads.

---

This PR will probably supersede #15 , but big thanks to @felipempda for posting that which pushed me to revisit this!