### PR TITLE
Add `publish-skip-configured-key` option to require a galaxy token on publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ usage: python -m galactory [-h] [-c CONFIG] [--listen-addr LISTEN_ADDR]
                            [--listen-port LISTEN_PORT] [--server-name SERVER_NAME]
                            --artifactory-path ARTIFACTORY_PATH
                            [--artifactory-api-key ARTIFACTORY_API_KEY] [--use-galaxy-key]
-                           [--prefer-configured-key] [--log-file LOG_FILE]
+                           [--prefer-configured-key] [--publish-skip-configured-key]
+                           [--log-file LOG_FILE]
                            [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--log-headers]
                            [--log-body] [--proxy-upstream PROXY_UPSTREAM]
                            [-npns NO_PROXY_NAMESPACE] [--cache-minutes CACHE_MINUTES]
@@ -59,6 +60,9 @@ optional arguments:
   --prefer-configured-key
                         If set, prefer the confgured Artifactory key over the Galaxy token.
                         [env var: GALACTORY_PREFER_CONFIGURED_KEY]
+ --publish-skip-configured-key
+                        If set, publish endpoint will not use a configured key, only Galaxy token.
+                        [env var: GALACTORY_PUBLISH_SKIP_CONFIGURED_KEY]
   --log-file LOG_FILE   If set, logging will go to this file instead of the console.
                         [env var: GALACTORY_LOG_FILE]
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}

--- a/changelogs/fragments/14-publish-skip-configured-key.yml
+++ b/changelogs/fragments/14-publish-skip-configured-key.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - publish endpoint - add ``PUBLISH_SKIP_CONFIGURED_KEY`` option which disallows using a configured API key on the ``publish`` endpoint (https://github.com/briantist/galactory/issues/14).

--- a/galactory/__main__.py
+++ b/galactory/__main__.py
@@ -45,6 +45,7 @@ if __name__ == '__main__':
     parser.add_argument('--artifactory-api-key', type=str, env_var='GALACTORY_ARTIFACTORY_API_KEY', help='If set, is the API key used to access Artifactory.')
     parser.add_argument('--use-galaxy-key', action='store_true', env_var='GALACTORY_USE_GALAXY_KEY', help='If set, uses the Galaxy token as the Artifactory API key.')
     parser.add_argument('--prefer-configured-key', action='store_true', env_var='GALACTORY_PREFER_CONFIGURED_KEY', help='If set, prefer the confgured Artifactory key over the Galaxy token.')
+    parser.add_argument('--publish-skip-configured-key', action='store_true', env_var='GALACTORY_PUBLISH_SKIP_CONFIGURED_KEY', help='If set, publish endpoint will not use a configured key, only Galaxy token.')
     parser.add_argument('--log-file', type=str, env_var='GALACTORY_LOG_FILE', help='If set, logging will go to this file instead of the console.')
     parser.add_argument(
         '--log-level',
@@ -73,6 +74,7 @@ if __name__ == '__main__':
         ARTIFACTORY_API_KEY=args.artifactory_api_key,
         USE_GALAXY_KEY=args.use_galaxy_key,
         PREFER_CONFIGURED_KEY=args.prefer_configured_key,
+        PUBLISH_SKIP_CONFIGURED_KEY=args.publish_skip_configured_key,
         SERVER_NAME=args.server_name,
         CACHE_MINUTES=args.cache_minutes,
         CACHE_READ=args.cache_read,

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -161,8 +161,9 @@ def version(namespace, collection, version):
 def publish():
     sha256 = request.form['sha256']
     file = request.files['file']
+    skip_configured_key = current_app.config['PUBLISH_SKIP_CONFIGURED_KEY']
 
-    target = authorize(request, current_app.config['ARTIFACTORY_PATH'] / file.filename)
+    target = authorize(request, current_app.config['ARTIFACTORY_PATH'] / file.filename, skip_configured_key=skip_configured_key)
 
     with _chunk_to_temp(Base64IO(file)) as tmp:
         if tmp.sha256 != sha256:

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -15,7 +15,7 @@ from urllib3 import Retry
 from requests.adapters import HTTPAdapter
 from requests import Session
 
-from flask import url_for, request, current_app, abort, Response
+from flask import url_for, request, current_app, abort, Response, Request
 from artifactory import ArtifactoryPath, ArtifactoryException
 from dohq_artifactory.auth import XJFrogArtApiAuth
 
@@ -36,9 +36,11 @@ def _session_with_retries(retry=None, auth=None) -> Session:
     return session
 
 
-def authorize(request, artifactory_path, retry=None) -> ArtifactoryPath:
+def authorize(request: Request, artifactory_path: ArtifactoryPath, retry=None, skip_configured_key: bool = False) -> ArtifactoryPath:
     auth = None
-    apikey = current_app.config['ARTIFACTORY_API_KEY']
+    apikey = None
+    if not skip_configured_key:
+        apikey = current_app.config['ARTIFACTORY_API_KEY']
 
     if current_app.config['USE_GALAXY_KEY'] and (not current_app.config['PREFER_CONFIGURED_KEY'] or not apikey):
         authorization = request.headers.get('Authorization')


### PR DESCRIPTION
Closes #14 

Adds `PUBLISH_SKIP_CONFIGURED_KEY` config (`--publish-skip-configured-key` CLI option).

When set, a configured API key will not be used for the `/publish` endpoint. This allows for a running instance with a configured API key to use that key only for proxying-related writes (cache, proxied collections) with anonymous clients, so that anonymous clients cannot publish collections.

Clients can still publish collections if they provide their API key via the galaxy token, so that `ansible-galaxy` sends it in the request.

To use that, `USE_GALAXY_KEY` must be `True`. 
