### PR TITLE
Fix URL generation for scheme and self-referential URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Pulling out this bit about configuration for emphasis:
 ```text
 usage: python -m galactory [-h] [-c CONFIG] [--listen-addr LISTEN_ADDR]
                            [--listen-port LISTEN_PORT] [--server-name SERVER_NAME]
+                           [--preferred-url-scheme PREFERRED_URL_SCHEME]
                            --artifactory-path ARTIFACTORY_PATH
                            [--artifactory-api-key ARTIFACTORY_API_KEY] [--use-galaxy-key]
                            [--prefer-configured-key] [--publish-skip-configured-key]
@@ -54,6 +55,10 @@ optional arguments:
   --server-name SERVER_NAME
                         The host name and port of the server, as seen from clients. Used for
                         generating links. [env var: GALACTORY_SERVER_NAME]
+  --preferred-url-scheme PREFERRED_URL_SCHEME
+                        Sets the preferred scheme to use when constructing URLs. Defaults to
+                        the request scheme, but is unaware of reverse proxies.
+                        [env var: GALACTORY_PREFERRED_URL_SCHEME]
   --artifactory-path ARTIFACTORY_PATH
                         The URL of the path in Artifactory where collections are stored.
                         [env var: GALACTORY_ARTIFACTORY_PATH]

--- a/changelogs/fragments/27-protocol-urls.yml
+++ b/changelogs/fragments/27-protocol-urls.yml
@@ -2,3 +2,4 @@
 bugfixes:
   - generated URLs had now way to set the scheme for use reverse proxies or load balancers (https://github.com/briantist/galactory/issues/27).
   - the ``href`` field in responses did not properly use the server name or the new support schemes (https://github.com/briantist/galactory/pull/29).
+  - the bare ``collections/`` endpoint was not using authorization and would have failed if authentication was required to read from Artifactory (https://github.com/briantist/galactory/pull/29).

--- a/changelogs/fragments/27-protocol-urls.yml
+++ b/changelogs/fragments/27-protocol-urls.yml
@@ -1,5 +1,6 @@
 ---
 bugfixes:
   - generated URLs had now way to set the scheme for use reverse proxies or load balancers (https://github.com/briantist/galactory/issues/27).
-  - the ``href`` field in responses did not properly use the server name or the new support schemes (https://github.com/briantist/galactory/pull/29).
+  - the ``href`` field in responses did not use the new support for schemes (https://github.com/briantist/galactory/pull/29).
   - the bare ``collections/`` endpoint was not using authorization and would have failed if authentication was required to read from Artifactory (https://github.com/briantist/galactory/pull/29).
+  - the ``/api/`` endpoint did not define a route that didn't end in ``/``, which caused Flask to issue a redirect, however the redirect does not use the preferred scheme (https://github.com/briantist/galactory/pull/29).

--- a/changelogs/fragments/27-protocol-urls.yml
+++ b/changelogs/fragments/27-protocol-urls.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - generated URLs had now way to set the scheme for use reverse proxies or load balancers (https://github.com/briantist/galactory/issues/27).
+  - the ``href`` field in responses did not properly use the server name or the new support schemes (https://github.com/briantist/galactory/pull/29).

--- a/galactory/__init__.py
+++ b/galactory/__init__.py
@@ -72,6 +72,7 @@ def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=F
     parser.add_argument('--listen-addr', default='0.0.0.0', type=str, env_var='GALACTORY_LISTEN_ADDR', help='The IP address to listen on.')
     parser.add_argument('--listen-port', default=5555, type=int, env_var='GALACTORY_LISTEN_PORT', help='The TCP port to listen on.')
     parser.add_argument('--server-name', type=str, env_var='GALACTORY_SERVER_NAME', help='The host name and port of the server, as seen from clients. Used for generating links.')
+    parser.add_argument('--preferred-url-scheme', type=str, env_var='GALACTORY_PREFERRED_URL_SCHEME', help='Sets the preferred scheme to use when constructing URLs. Defaults to the request scheme, but is unaware of reverse proxies.')
     parser.add_argument('--artifactory-path', type=str, required=True, env_var='GALACTORY_ARTIFACTORY_PATH', help='The URL of the path in Artifactory where collections are stored.')
     parser.add_argument('--artifactory-api-key', type=str, env_var='GALACTORY_ARTIFACTORY_API_KEY', help='If set, is the API key used to access Artifactory.')
     parser.add_argument('--use-galaxy-key', action='store_true', env_var='GALACTORY_USE_GALAXY_KEY', help='If set, uses the Galaxy token as the Artifactory API key.')
@@ -112,6 +113,7 @@ def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=F
         PREFER_CONFIGURED_KEY=args.prefer_configured_key,
         PUBLISH_SKIP_CONFIGURED_KEY=args.publish_skip_configured_key,
         SERVER_NAME=args.server_name,
+        PREFERRED_URL_SCHEME=args.preferred_url_scheme,
         CACHE_MINUTES=args.cache_minutes,
         CACHE_READ=args.cache_read,
         CACHE_WRITE=args.cache_write,

--- a/galactory/api/__init__.py
+++ b/galactory/api/__init__.py
@@ -16,7 +16,7 @@ API_RESPONSE = {
 bp = Blueprint('api', __name__, url_prefix='/api')
 bp.register_blueprint(v2)
 
-
+@bp.route('')
 @bp.route('/')
 def api():
     return jsonify(API_RESPONSE)

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -157,7 +157,7 @@ def version(namespace, collection, version):
         'namespace': info['namespace'],
         'download_url': info['download_url'],
         'hidden': False,
-        'href': request.url,
+        'href': url_for(request.endpoint, _external=True, _scheme=_scheme, **request.view_args),
         'id': 0,
         'metadata': info['collection_info'],
         'version': version,

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -70,6 +70,7 @@ def versions(namespace, collection):
     cache_minutes = current_app.config['CACHE_MINUTES']
     cache_read = current_app.config['CACHE_READ']
     cache_write = current_app.config['CACHE_WRITE']
+    _scheme=current_app.config.get('PREFERRED_URL_SCHEME')
 
     upstream_result = None
     if upstream and (not no_proxy or namespace not in no_proxy):
@@ -95,6 +96,7 @@ def versions(namespace, collection):
                         collection=i['name'],
                         version=v,
                         _external=True,
+                        _scheme=_scheme,
                     ),
                     'version': v,
                 }
@@ -124,6 +126,7 @@ def version(namespace, collection, version):
     cache_minutes = current_app.config['CACHE_MINUTES']
     cache_read = current_app.config['CACHE_READ']
     cache_write = current_app.config['CACHE_WRITE']
+    _scheme=current_app.config.get('PREFERRED_URL_SCHEME')
 
     try:
         info = next(discover_collections(repository, namespace=namespace, name=collection, version=version))
@@ -142,7 +145,13 @@ def version(namespace, collection, version):
             'size': info['size'],
         },
         'collection': {
-            'href': url_for('api.v2.collection', namespace=namespace, collection=collection, _external=True),
+            'href': url_for(
+                'api.v2.collection',
+                namespace=namespace,
+                collection=collection,
+                _external=True,
+                _scheme=_scheme,
+            ),
             'name': info['name'],
         },
         'namespace': info['namespace'],
@@ -163,6 +172,7 @@ def publish():
     file = request.files['file']
     skip_configured_key = current_app.config['PUBLISH_SKIP_CONFIGURED_KEY']
     property_fallback = current_app.config.get('USE_PROPERTY_FALLBACK', False)
+    _scheme = current_app.config.get('PREFERRED_URL_SCHEME')
 
     target = authorize(request, current_app.config['ARTIFACTORY_PATH'] / file.filename, skip_configured_key=skip_configured_key)
 
@@ -172,4 +182,4 @@ def publish():
 
         upload_collection_from_hashed_tempfile(target, tmp, property_fallback=property_fallback)
 
-    return jsonify(task=url_for('api.v2.import_singleton', _external=True))
+    return jsonify(task=url_for('api.v2.import_singleton', _external=True, _scheme=_scheme))

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -65,6 +65,8 @@ def load_manifest_from_archive(handle, seek_to_zero_after=True):
 
 
 def discover_collections(repo, namespace=None, name=None, version=None, fast_detection=True):
+    _scheme=current_app.config.get('PREFERRED_URL_SCHEME')
+
     for p in repo:
         if fast_detection:
             # we're going to use the naming convention to eliminate candidates early,
@@ -108,6 +110,7 @@ def discover_collections(repo, namespace=None, name=None, version=None, fast_det
                 'download.download',
                 filename=p.name,
                 _external=True,
+                _scheme=_scheme,
             ),
             'mime_type': info.mime_type,
             'version': props['version'][0],
@@ -146,6 +149,8 @@ def collected_collections(repo, namespace=None, name=None):
 
 
 def _collection_listing(repo, namespace=None, collection=None):
+    _scheme=current_app.config.get('PREFERRED_URL_SCHEME')
+
     collections = collected_collections(repo, namespace, collection)
 
     results = []
@@ -164,6 +169,7 @@ def _collection_listing(repo, namespace=None, collection=None):
                 namespace=latest['namespace']['name'],
                 collection=latest['name'],
                 _external=True,
+                _scheme=_scheme,
             ),
             'latest_version': {
                 'href': url_for(
@@ -172,6 +178,7 @@ def _collection_listing(repo, namespace=None, collection=None):
                     collection=latest['name'],
                     version=latest['version'],
                     _external=True,
+                    _scheme=_scheme,
                 ),
                 "version": latest['version'],
             }

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -159,7 +159,7 @@ def _collection_listing(repo, namespace=None, collection=None):
         latest = i['latest']
 
         result = {
-            'href': request.url,
+            'href': url_for(request.endpoint, _external=True, _scheme=_scheme, **request.view_args),
             'name': latest['name'],
             'namespace': latest['namespace'],
             'created': latest['created'],

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -64,9 +64,7 @@ def load_manifest_from_archive(handle, seek_to_zero_after=True):
                 return data
 
 
-def discover_collections(repo, namespace=None, name=None, version=None, fast_detection=True):
-    _scheme=current_app.config.get('PREFERRED_URL_SCHEME')
-
+def discover_collections(repo, namespace=None, name=None, version=None, fast_detection=True, scheme=None):
     for p in repo:
         if fast_detection:
             # we're going to use the naming convention to eliminate candidates early,
@@ -110,7 +108,7 @@ def discover_collections(repo, namespace=None, name=None, version=None, fast_det
                 'download.download',
                 filename=p.name,
                 _external=True,
-                _scheme=_scheme,
+                _scheme=scheme,
             ),
             'mime_type': info.mime_type,
             'version': props['version'][0],
@@ -127,10 +125,10 @@ def discover_collections(repo, namespace=None, name=None, version=None, fast_det
             yield coldata
 
 
-def collected_collections(repo, namespace=None, name=None):
+def collected_collections(repo, namespace=None, name=None, scheme=None):
     collections = {}
 
-    for c in discover_collections(repo, namespace=namespace, name=name):
+    for c in discover_collections(repo, namespace=namespace, name=name, scheme=scheme):
         version = c['version']
         ver = c['semver']
         col = collections.setdefault(c['fqcn'], {})
@@ -148,9 +146,7 @@ def collected_collections(repo, namespace=None, name=None):
     return collections
 
 
-def _collection_listing(repo, namespace=None, collection=None):
-    _scheme=current_app.config.get('PREFERRED_URL_SCHEME')
-
+def _collection_listing(repo, namespace=None, collection=None, scheme=None):
     collections = collected_collections(repo, namespace, collection)
 
     results = []
@@ -159,7 +155,7 @@ def _collection_listing(repo, namespace=None, collection=None):
         latest = i['latest']
 
         result = {
-            'href': url_for(request.endpoint, _external=True, _scheme=_scheme, **request.view_args),
+            'href': url_for(request.endpoint, _external=True, _scheme=scheme, **request.view_args),
             'name': latest['name'],
             'namespace': latest['namespace'],
             'created': latest['created'],
@@ -169,7 +165,7 @@ def _collection_listing(repo, namespace=None, collection=None):
                 namespace=latest['namespace']['name'],
                 collection=latest['name'],
                 _external=True,
-                _scheme=_scheme,
+                _scheme=scheme,
             ),
             'latest_version': {
                 'href': url_for(
@@ -178,7 +174,7 @@ def _collection_listing(repo, namespace=None, collection=None):
                     collection=latest['name'],
                     version=latest['version'],
                     _external=True,
-                    _scheme=_scheme,
+                    _scheme=scheme,
                 ),
                 "version": latest['version'],
             }


### PR DESCRIPTION
As reported in #27 , there was no way to set the scheme of the generated URLs.

In fixing this I also noticed places where we used `request.url` when we needed to set the `href` field in certain requests. Since those were not generated, they did not use the scheme nor did they necessarily use the correct server name. Those fields are not used by `ansible-galaxy` as far as I know so it wasn't a breaking thing but was incorrect nonetheless.

Fixes #27 