### PR TITLE
Control `Accept` header on upstream proxying, add support for brotli compression

### DIFF
--- a/changelogs/fragments/32-headers-brotli.yml
+++ b/changelogs/fragments/32-headers-brotli.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - upstream proxying - proxied requests used the ``Accept:`` header of the request, sometimes resulting in HTML from the upstream and a resulting 500 error since the response was not JSON (https://github.com/briantist/galactory/issues/31).
+  - "upstream proxying - proxied requests with an ``Accept-Encoding: br`` (brotli compression) header would fail decoding because of the lack of a brotli decoder (https://github.com/briantist/galactory/pull/32)."

--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -226,6 +226,7 @@ class ProxyUpstream:
         current_app.logger.info(f"Rewriting '{this_url}' to '{rewritten}'")
 
         headers = {k: v for k, v in request.headers.items() if k not in ['Authorization', 'Host']}
+        headers['Accept'] = 'application/json, */*'
 
         req = requests.Request(method=request.method, url=rewritten, headers=headers, data=request.data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Flask>=2.1,<3
 semver>=2,<3
 base64io>=1,<2
 ConfigArgParse>=1.5,<2
+requests>=2.26.0,<3
+brotli>=1,<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,5 @@ install_requires =
     semver>=2,<3
     base64io>=1,<2
     ConfigArgParse>=1.5,<2
+    requests>=2.26.0,<3
+    brotli>=1,<2


### PR DESCRIPTION
Fixes #31 

- Ensures that the `Accept:` header for upstream requests asks for JSON first (ex: browser-based requests may ask for HTML first)
- Adds support for brotli compression from upstreams (ex: when passing through request from browser, it mentions support for brotli [`Accept-Encoding: br`] which caused galactory to crash because no brotli package was available to decode it

I'm not changing the `Accept-Encoding` header at this time as I can't seem to find a reliable way to ask `requests` which formats it supports, but in testing, it seemed like adding brotli allowed it to support all the standard formats (as in, brotli was the only one missing/not supported natively).