### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ usage: python -m galactory [-h] [-c CONFIG] [--listen-addr LISTEN_ADDR]
                            [--log-body] [--proxy-upstream PROXY_UPSTREAM]
                            [-npns NO_PROXY_NAMESPACE] [--cache-minutes CACHE_MINUTES]
                            [--cache-read CACHE_READ] [--cache-write CACHE_WRITE]
+                           [--use-property-fallback]
+                           [--health-check-custom-text HEALTH_CHECK_CUSTOM_TEXT]
 
 galactory is a partial Ansible Galaxy proxy that uploads and downloads collections, using an
 Artifactory generic repository as its backend.
@@ -102,6 +104,9 @@ optional arguments:
                         Requires a Pro license of Artifactory. This feature is a workaround for an
                         Artifactory proxy configuration error and may be removed in a future version.
                         [env var: GALACTORY_USE_PROPERTY_FALLBACK]
+  --health-check-custom-text HEALTH_CHECK_CUSTOM_TEXT
+                        Sets custom_text field for health check endpoint responses.
+                        [env var: GALACTORY_HEALTH_CHECK_CUSTOM_TEXT]
 
 Args that start with '--' (eg. --listen-addr) can also be set in a config file
 (/etc/galactory.d/*.conf or ~/.galactory/*.conf or specified via -c). Config file syntax allows:

--- a/changelogs/fragments/30-healthchecks.yml
+++ b/changelogs/fragments/30-healthchecks.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - healthchecks - the first health check endpoint has been added, which can be used for load balancers, reverse proxies, smart DNS, and more (https://github.com/briantist/galactory/issues/30).

--- a/galactory/__init__.py
+++ b/galactory/__init__.py
@@ -11,6 +11,7 @@ from artifactory import ArtifactoryPath
 
 from .api import bp as api
 from .download import bp as download
+from .health import bp as health
 
 class DateTimeIsoFormatJSONEncoder(JSONEncoder):
     def default(self, o):
@@ -24,6 +25,7 @@ def create_app(**config):
     app = Flask(__name__)
     app.json_encoder = DateTimeIsoFormatJSONEncoder
     app.config.update(**config)
+    app.register_blueprint(health)
     app.register_blueprint(api)
     app.register_blueprint(download)
 
@@ -94,6 +96,7 @@ def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=F
     parser.add_argument('--cache-read', action=_StrBool, default=True, env_var='GALACTORY_CACHE_READ', help='Look for upsteam caches and use their values.')
     parser.add_argument('--cache-write', action=_StrBool, default=True, env_var='GALACTORY_CACHE_WRITE', help='Populate the upstream cache in Artifactory. Should be false when no API key is provided or the key has no permission to write.')
     parser.add_argument('--use-property-fallback', action='store_true', env_var='GALACTORY_USE_PROPERTY_FALLBACK', help='Set properties of an uploaded collection in a separate request after publshinng. Requires a Pro license of Artifactory. This feature is a workaround for an Artifactory proxy configuration error and may be removed in a future version.')
+    parser.add_argument('--health-check-custom-text', type=str, default='', env_var='GALACTORY_HEALTH_CHECK_CUSTOM_TEXT', help='Sets custom_text field for health check endpoint responses.')
 
     if parse_known_only:
         args, _ = parser.parse_known_args()
@@ -118,6 +121,7 @@ def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=F
         CACHE_READ=args.cache_read,
         CACHE_WRITE=args.cache_write,
         USE_PROPERTY_FALLBACK=args.use_property_fallback,
+        HEALTH_CHECK_CUSTOM_TEXT=args.health_check_custom_text,
     )
 
     if run:

--- a/galactory/health/__init__.py
+++ b/galactory/health/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 Brian Scholer (@briantist)
+
+from flask import Blueprint, jsonify
+
+from .v1 import bp as v1
+
+API_RESPONSE = {
+    'available_versions': {
+        'v1': 'v1/',
+    },
+    'current_version': 'v1',
+    'description': 'Galactory Health Checks',
+}
+
+bp = Blueprint('health', __name__, url_prefix='/health')
+bp.register_blueprint(v1)
+
+@bp.route('')
+@bp.route('/')
+def health():
+    return jsonify(API_RESPONSE)

--- a/galactory/health/v1/__init__.py
+++ b/galactory/health/v1/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 Brian Scholer (@briantist)
+
+from flask import Blueprint
+
+bp = Blueprint('v1', __name__, url_prefix='/v1')
+bp.get_send_file_max_age = lambda x: 0
+
+from . import(
+    health_checks,
+)

--- a/galactory/health/v1/health_checks.py
+++ b/galactory/health/v1/health_checks.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# (c) 2022 Brian Scholer (@briantist)
+
+from datetime import datetime
+from time import perf_counter
+from flask import jsonify, g as ctx, current_app
+
+from . import bp
+
+
+@bp.before_request
+def start_timer():
+    ctx.start_time = perf_counter()
+
+
+@bp.after_request
+def commonize(response):
+    elapsed_ms = int((perf_counter() - ctx.start_time) * 1000)
+
+    data = response.get_json()
+
+    data['elapsed_ms'] = elapsed_ms
+    data['response_time'] = datetime.utcnow()
+    data['custom_text'] = current_app.config.get('HEALTH_CHECK_CUSTOM_TEXT', '')
+
+    response.data = current_app.json.dumps(data)
+
+    response.headers['Cache-Control'] = "no-cache, no-store, must-revalidate"
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = '0'
+
+    return response
+
+
+@bp.route('/basic')
+@bp.route('/basic/')
+def basic():
+    out = {
+        'type': 'basic'
+    }
+    return jsonify(out)
+
+
+#TODO: add more healthcheck types?


### PR DESCRIPTION
Related: 
- #30 

This only adds a basic endpoint so will keep #30 open for now.

- Adds the `/health` endpoint to describe health API versions.
- Adds the `/health/v1/basic` endpoint as a general check that the webserver is running.
- Adds the `HEALTH_CHECK_CUSTOM_TEXT` option which adds some configurable text to the `custom_text` field of the health responses.