### PR TITLE
add href to health check responses

### DIFF
--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -22,7 +22,7 @@ from ...upstream import ProxyUpstream
 @v2.route('/collections/')
 def collections():
     repository = authorize(request, current_app.config['ARTIFACTORY_PATH'])
-    scheme=current_app.config.get('PREFERRED_URL_SCHEME')
+    scheme = current_app.config.get('PREFERRED_URL_SCHEME')
 
     results = _collection_listing(repo=repository, scheme=scheme)
     return jsonify(results=results)
@@ -37,7 +37,7 @@ def collection(namespace, collection):
     cache_minutes = current_app.config['CACHE_MINUTES']
     cache_read = current_app.config['CACHE_READ']
     cache_write = current_app.config['CACHE_WRITE']
-    scheme=current_app.config.get('PREFERRED_URL_SCHEME')
+    scheme = current_app.config.get('PREFERRED_URL_SCHEME')
 
     upstream_result = None
     if upstream and (not no_proxy or namespace not in no_proxy):
@@ -74,7 +74,7 @@ def versions(namespace, collection):
     cache_minutes = current_app.config['CACHE_MINUTES']
     cache_read = current_app.config['CACHE_READ']
     cache_write = current_app.config['CACHE_WRITE']
-    scheme=current_app.config.get('PREFERRED_URL_SCHEME')
+    scheme = current_app.config.get('PREFERRED_URL_SCHEME')
 
     upstream_result = None
     if upstream and (not no_proxy or namespace not in no_proxy):
@@ -130,7 +130,7 @@ def version(namespace, collection, version):
     cache_minutes = current_app.config['CACHE_MINUTES']
     cache_read = current_app.config['CACHE_READ']
     cache_write = current_app.config['CACHE_WRITE']
-    scheme=current_app.config.get('PREFERRED_URL_SCHEME')
+    scheme = current_app.config.get('PREFERRED_URL_SCHEME')
 
     try:
         info = next(discover_collections(repository, namespace=namespace, name=collection, version=version, scheme=scheme))

--- a/galactory/health/v1/health_checks.py
+++ b/galactory/health/v1/health_checks.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime
 from time import perf_counter
-from flask import jsonify, g as ctx, current_app
+from flask import jsonify, g as ctx, current_app, url_for, request
 
 from . import bp
 
@@ -17,11 +17,15 @@ def start_timer():
 def commonize(response):
     elapsed_ms = int((perf_counter() - ctx.start_time) * 1000)
 
+    scheme = current_app.config.get('PREFERRED_URL_SCHEME')
+    custom_txt = current_app.config.get('HEALTH_CHECK_CUSTOM_TEXT', '')
+
     data = response.get_json()
 
     data['elapsed_ms'] = elapsed_ms
     data['response_time'] = datetime.utcnow()
-    data['custom_text'] = current_app.config.get('HEALTH_CHECK_CUSTOM_TEXT', '')
+    data['custom_text'] = custom_txt
+    data['href'] = url_for(request.endpoint, _external=True, _scheme=scheme, **request.view_args)
 
     response.data = current_app.json.dumps(data)
 


### PR DESCRIPTION
Addendum to #33 adding an `href` field to health check responses.
This can be useful to ensure URL generation is working. 
Also fixed some formatting.

cc @jcox10 
