### PR TITLE
add minimal ProxyFix support

### DIFF
--- a/changelogs/fragments/48-proxyfix.yml
+++ b/changelogs/fragments/48-proxyfix.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - factory methods - add basic support for ``ProxyFix`` to the ``create_configured_app`` factory method (https://github.com/briantist/galactory/pull/48).

--- a/galactory/__init__.py
+++ b/galactory/__init__.py
@@ -4,6 +4,7 @@
 import logging
 
 from flask import Flask, request
+from werkzeug.middleware.proxy_fix import ProxyFix
 from configargparse import ArgParser, ArgumentError, Action
 from artifactory import ArtifactoryPath
 
@@ -13,6 +14,7 @@ from .api import bp as api
 from .download import bp as download
 from .health import bp as health
 from .root import bp as root
+
 
 def create_app(**config):
     app = Flask(__name__)
@@ -54,7 +56,7 @@ class _StrBool(Action):
         setattr(namespace, self.dest, self._booler(values))
 
 
-def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=False):
+def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=False, proxy_fix=False, **extra):
     parser = ArgParser(
         prog='python -m galactory',
         description=(
@@ -117,6 +119,10 @@ def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=F
         USE_PROPERTY_FALLBACK=args.use_property_fallback,
         HEALTH_CHECK_CUSTOM_TEXT=args.health_check_custom_text,
     )
+
+    if proxy_fix:
+        proxy_args = {k: v for k, v in extra if k.startswith('x_')}
+        app = ProxyFix(app, **proxy_args)
 
     if run:
         app.run(args.listen_addr, args.listen_port, threaded=True)

--- a/galactory/__init__.py
+++ b/galactory/__init__.py
@@ -121,7 +121,7 @@ def create_configured_app(run=False, parse_known_only=True, parse_allow_abbrev=F
     )
 
     if proxy_fix:
-        proxy_args = {k: v for k, v in extra if k.startswith('x_')}
+        proxy_args = {k: v for k, v in extra.items() if k.startswith('x_')}
         app = ProxyFix(app, **proxy_args)
 
     if run:


### PR DESCRIPTION
related:
- #29 
- #45 
- #27 

While the `PREFERRED_URL_SCHEME` options adds some basic support, for actual reverse proxy use cases, the `ProxyFix` method suggested by @jcox10 is better. But it cannot be used in all circumstances; it must be used only when an actual proxy is in use, and it must be configured with the correct numbers for the headers, so it varies with each use case.

Being a Flask app, galactory should be run with a production WSGI server, and how to configure that server is up to each implementer, so I don't want to add too many options for this directly.

But this PR does add a basic way of configuring it. This method cannot be set with CLI/config options; rather it's done through arguments on the `create_configured_app` factory method, for example `create_configured_app(proxy_fix=True, x_for=2, x_proto=2, x_port=2)` where all the `x_` options are optional and correspond to the options of the same name in the `ProxyFix` constructor.

This can be used with WSGI servers like `gunicorn`, so where before it may have been used like:

```
gunicorn 'galactory:create_configured_app'
```

it can now be used like:

```
gunicorn 'galactory:create_configured_app(proxy_fix=True, x_for=2)'
```

---

Using `ProxyFix` with `x_proto` (which defaults to `1`) means not having to set `PREFERRED_URL_SCHEME` as long as the proxy sets the `X-Forwarded-Proto` header.
