### PR TITLE
url quote collection info

### DIFF
--- a/changelogs/fragments/58-encode-collection-info
+++ b/changelogs/fragments/58-encode-collection-info
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+bugfixes:
   - Encode special characters in ``collection_info`` when uploading collection file to artifactory to prevent truncation (https://github.com/briantist/galactory/issues/58).

--- a/changelogs/fragments/58-encode-collection-info
+++ b/changelogs/fragments/58-encode-collection-info
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Encode special characters in collection_info when uploading collection file to artifactory to prevent truncation (https://github.com/briantist/galactory/issues/58)

--- a/changelogs/fragments/58-encode-collection-info
+++ b/changelogs/fragments/58-encode-collection-info
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Encode special characters in collection_info when uploading collection file to artifactory to prevent truncation (https://github.com/briantist/galactory/issues/58)
+  - Encode special characters in ``collection_info`` when uploading collection file to artifactory to prevent truncation (https://github.com/briantist/galactory/issues/58).

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from tempfile import SpooledTemporaryFile
 from urllib.request import urlopen
 from urllib3 import Retry
-from urllib3.parse import quote
+from urllib.parse import quote
 from requests.adapters import HTTPAdapter
 from requests import Session
 

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from tempfile import SpooledTemporaryFile
 from urllib.request import urlopen
 from urllib3 import Retry
+from urllib3.parse import quote
 from requests.adapters import HTTPAdapter
 from requests import Session
 
@@ -248,7 +249,7 @@ def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: H
     else:
         ci = manifest['collection_info']
         props = {
-            'collection_info': json.dumps(ci),
+            'collection_info': quote(json.dumps(ci)),
             'namespace': ci['namespace'],
             'name': ci['name'],
             'version': ci['version'],


### PR DESCRIPTION
Use `urllib.parse.quote` to encode any special characters in the collection info. Prevents any query string parameters in the collection info from getting interpreted by Artifactory.

Fixes: #58 
Fixes: #52
Closes: #54 