### PR TITLE
Fix URL quoting for collection info

### DIFF
--- a/changelogs/fragments/72-fix-url-quoting.yml
+++ b/changelogs/fragments/72-fix-url-quoting.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - the minimum required version of ``dohq-artifactory`` is now ``v0.9.0`` (https://github.com/briantist/galactory/pull/72).
+
+bugfixes:
+  - traceback when publishing a collection whose metadata contains certain characters that need to be URL quoted (https://github.com/briantist/galactory/issues/58, https://github.com/briantist/galactory/issues/52).

--- a/changelogs/fragments/72-fix-url-quoting.yml
+++ b/changelogs/fragments/72-fix-url-quoting.yml
@@ -3,4 +3,7 @@ minor_changes:
   - the minimum required version of ``dohq-artifactory`` is now ``v0.9.0`` (https://github.com/briantist/galactory/pull/72).
 
 bugfixes:
-  - traceback when publishing a collection whose metadata contains certain characters that need to be URL quoted (https://github.com/briantist/galactory/issues/58, https://github.com/briantist/galactory/issues/52).
+  - traceback when publishing or retrieving a previously published collection (even by proxying) whose metadata contains certain characters that need to be URL quoted (https://github.com/briantist/galactory/issues/58, https://github.com/briantist/galactory/issues/52).
+
+known_issues:
+  - any collections already published with malformed metadata due to the bug in ``collection_info`` will not be fixed and will need to be re-published or have their collection info repaired (https://github.com/briantist/galactory/pull/72).

--- a/galactory/upstream.py
+++ b/galactory/upstream.py
@@ -145,7 +145,7 @@ class ProxyUpstream:
             cache.update()
             json.dump(cache._to_serializable_dict(), buffer, default=DateTimeIsoFormatJSONProvider.default)
             buffer.seek(0)
-            path.deploy(buffer)
+            path.deploy(buffer, quote_parameters=True)
 
     @contextmanager
     def proxy_download(self, request):

--- a/galactory/utilities.py
+++ b/galactory/utilities.py
@@ -260,7 +260,14 @@ def upload_collection_from_hashed_tempfile(artifact: ArtifactoryPath, tmpfile: H
         params = {}
 
     try:
-        artifact.deploy(tmpfile.handle, md5=tmpfile.md5, sha1=tmpfile.sha1, sha256=tmpfile.sha256, parameters=params)
+        artifact.deploy(
+            tmpfile.handle,
+            md5=tmpfile.md5,
+            sha1=tmpfile.sha1,
+            sha256=tmpfile.sha256,
+            parameters=params,
+            quote_parameters=True
+        )
     except ArtifactoryException as exc:
         cause = exc.__cause__
         current_app.logger.debug(cause)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dohq-artifactory>=0.8,<0.9
+dohq-artifactory>=0.9,<0.10
 Flask>=2.1,<3
 semver>=2,<3
 base64io>=1,<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ zip_safe = True
 include_package_data = True
 python_requires = >= 3.6
 install_requires =
-    dohq-artifactory>=0.8,<0.9
+    dohq-artifactory>=0.9,<0.10
     Flask>=2.1,<3
     semver>=2,<3
     base64io>=1,<2


### PR DESCRIPTION
Fixes: #58 
Fixes: #52 
Closes: #54 
Closes: #59 
Closes: #71 

With https://github.com/devopshq/artifactory/pull/409 merged, the underlying issue is fixed upstream, we just need to consume it by setting the parameter appropriately since it currently defaults to previous behavior.

This PR does that, and to avoid guard code, it also sets the minimum version of that library to the newly released `v0.9.0` .

Huge thanks to @jcox10 @mamercad for raising the issue and doing the heavy troubleshooting!

---

# Important

The malformation of collection info happened on publish, which, for collections uploaded (cached) via proxying, will have happened silently and then affected subsequent pulls.

The fix in this PR cannot fix collections which have already been published in artifactory with malformed `collection_info`, so errors will still be seen trying to retrieve those.

The collection info could be manually repaired, but the recommended fix is to republish.

### For collections that were not proxied
I recommend re-publishing the collection (and probably delete the existing ones beforehand).

### For collections that were proxied
I recommend deleting all (or all affected) proxied collections, and letting them get re-populated naturally on request.