### PR TITLE
redo publishing workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,9 @@ jobs:
 
   pypi_release:
     needs: [test, build]
-    if: github.event_name == 'push'
+    if: >-
+      github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -172,7 +174,6 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@f5622bde02b04381239da3573277701ceca8f6a0
 
   github_release:
@@ -181,7 +182,9 @@ jobs:
       - build
       - container_release
       - pypi_release
-    if: github.event_name == 'push'
+    if: >-
+      github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -193,7 +196,6 @@ jobs:
           path: dist
 
       - uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,10 +124,15 @@ jobs:
           if-no-files-found: error
 
 
-  release:
+  container_release:
     needs: [test, build]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # ^ checkout
+      packages: write
+      # ^ ghcr
     env:
       UPSTREAM: ghcr.io/${{ github.repository_owner }}/galactory
     steps:
@@ -153,6 +158,14 @@ jobs:
             ${{ env.UPSTREAM }}:${{ startsWith(github.ref, 'refs/tags/') && 'latest' || needs.test.outputs.branch }}
             ${{ env.UPSTREAM }}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }}
 
+  pypi_release:
+    needs: [test, build]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      # ^ PyPI OIDC
+    steps:
       - uses: actions/download-artifact@v3
         with:
           name: dist
@@ -161,9 +174,23 @@ jobs:
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@f5622bde02b04381239da3573277701ceca8f6a0
+
+  github_release:
+    needs:
+      - test
+      - build
+      - container_release
+      - pypi_release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # ^ GitHub tag and release
+    steps:
+      - uses: actions/download-artifact@v3
         with:
-          user: __token__
-          password: ${{ secrets.pypi }}
+          name: dist
+          path: dist
 
       - uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Resolves #70 

- splits the release job into 3 separate jobs
  - the main reason for this is to give least permission to each of the job types
  - the job types are "container" (build and push to ghcr), "pypi" (publish to pypi), and "github" (creating the release page)
- the pypi publish now uses OIDC (trusted publisher) integration, so once confirmed working I can revoke the token I generated and remove that secret from the repo settings