### PR TITLE
container label: fix source URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           labels: |
-            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           tags: |
             ${{ env.UPSTREAM }}:${{ startsWith(github.ref, 'refs/tags/') && 'latest' || needs.test.outputs.branch }}
             ${{ env.UPSTREAM }}:${{ startsWith(github.ref, 'refs/tags/') && needs.test.outputs.relver || github.sha }}


### PR DESCRIPTION
Fixes a mistaken URL in #95 

We were setting `org.opencontainers.image.source` to the git URL, like `git://github.com/briantist/galactory.git` instead of `https://github.com/briantist/galactory`.

This should fix it.