### PR TITLE
fix another 500 error on no local collection

### DIFF
--- a/changelogs/fragments/114-bugfixes.yml
+++ b/changelogs/fragments/114-bugfixes.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - Requests for collections that were not already present in artifactory resulted in a 500 internal server error (https://github.com/briantist/galactory/issues/112).
+  - Requests for collections that were not already present in artifactory resulted in a 500 internal server error (https://github.com/briantist/galactory/issues/112, https://github.com/briantist/galactory/pull/116).
   - Requests proxied to a v2 upstream endpoint that supports pagination caused a 400 error from the upstream due to the inclusion of the v3 ``limit`` query string parameter (https://github.com/briantist/galactory/issues/113).

--- a/galactory/api/v2/collections.py
+++ b/galactory/api/v2/collections.py
@@ -105,7 +105,7 @@ def collection(namespace, collection):
 
     if upstream_result:
         if colgroup is None:
-            result = upstream_result
+            return upstream_result
         else:
             try:
                 upstream_version = VersionInfo.parse(upstream_result['latest_version']['version'])

--- a/galactory/api/v3/collections.py
+++ b/galactory/api/v3/collections.py
@@ -118,7 +118,7 @@ def collection(namespace, collection):
 
     if upstream_result:
         if colgroup is None:
-            result = upstream_result
+            return upstream_result
         else:
             try:
                 upstream_version = VersionInfo.parse(upstream_result['highest_version']['version'])


### PR DESCRIPTION
Related:
- #112 
- #114 

Another case that I missed in #114 because strangely `ansible-galaxy` seems to be able to avoid the affected endpoint altogether, but only sometimes.