### PR TITLE
container build matrix should not fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [arm64, amd64]
     outputs:


### PR DESCRIPTION
Want to know when one fails but the other succeeds.

Related:
- #115 
- https://github.com/briantist/galactory/actions/runs/6462419464/job/17543982259?pr=118
